### PR TITLE
People-scoring: nest JF ranges under JF weight, drop Seniority factor

### DIFF
--- a/skills/sumble-people-scoring/example/config.json
+++ b/skills/sumble-people-scoring/example/config.json
@@ -23,22 +23,15 @@
   ],
   "weights": {
     "jf": {
-      "default": 38.0,
-      "current": 38.0,
+      "default": 70.37,
+      "current": 70.37,
       "min": 0,
       "max": 100,
       "label": "Job Function (%)"
     },
-    "seniority": {
-      "default": 46.0,
-      "current": 46.0,
-      "min": 0,
-      "max": 100,
-      "label": "Seniority (%)"
-    },
     "skills": {
-      "default": 16.0,
-      "current": 16.0,
+      "default": 29.63,
+      "current": 29.63,
       "min": 0,
       "max": 100,
       "label": "Skills (%)"

--- a/skills/sumble-people-scoring/example/score_leads.py
+++ b/skills/sumble-people-scoring/example/score_leads.py
@@ -12,7 +12,6 @@ people-scoring-weights.json -> scoring_formula):
     seniority_frac  = job_level_rank / max_job_level_rank
     jf_score        = jf_range[slug].min
                       + (jf_range[slug].max - jf_range[slug].min) * seniority_frac
-    seniority_score = seniority_frac
     skill_score     = min(skill_count, skill_cap) / skill_cap
     <signal>_score  = <signal>_norm        (already 0-1)
     people_score    = Σ (weight_pct/100) * factor_score      # lands in [0, 1]
@@ -86,7 +85,6 @@ def score_row(row: dict[str, Any], spec: dict[str, Any]) -> dict[str, float]:
 
     factor_scores: dict[str, float] = {
         "jf": jf_score,
-        "seniority": sen_frac,
         "skills": skill_score,
     }
     # 1P signals contribute their pre-normalised <norm_column> value directly.
@@ -135,7 +133,7 @@ def main() -> int:
     if args.top > 0:
         scored = scored[: args.top]
 
-    extra_cols = ["rank", "people_score", "jf_score", "seniority_score", "skills_score"]
+    extra_cols = ["rank", "people_score", "jf_score", "skills_score"]
     extra_cols += [f"{(s.get('weight_key') or s.get('key'))}_score"
                    for s in spec["one_p_signals"]]
     base_cols = list(rows[0].keys())

--- a/skills/sumble-people-scoring/example/score_sheet.py
+++ b/skills/sumble-people-scoring/example/score_sheet.py
@@ -21,7 +21,6 @@ and at startup, and the in-app Download button serves the same sheet.
 The score mirrors the app's client math and score_leads.py exactly:
   seniority_frac  = job_level_rank / max_job_level_rank
   jf_score        = jf_range.min + (jf_range.max - jf_range.min) * seniority_frac
-  seniority_score = seniority_frac
   skill_score     = min(skill_count, skill_cap) / skill_cap
   1p factor       = its pre-normalised <norm_column> value
   people_score    = 100 * Σ (weight_pct/100) * factor_score
@@ -78,7 +77,7 @@ def factor_scores(row: dict, config: dict) -> dict[str, float]:
     cap = config.get("skill_cap", 5) or 5
     skill_score = min(_f(row.get("skill_count")), cap) / cap
 
-    out = {"jf": jf_score, "seniority": sen_frac, "skills": skill_score}
+    out = {"jf": jf_score, "skills": skill_score}
     for sig in config.get("one_p_signals", []) or []:
         key = sig.get("weight_key") or f"1p_{sig.get('key')}"
         out[key] = _f(row.get(sig.get("norm_column") or f"{sig.get('key')}_norm"))

--- a/skills/sumble-people-scoring/example/static/app.js
+++ b/skills/sumble-people-scoring/example/static/app.js
@@ -50,14 +50,12 @@ function scoreRow(row, config) {
   const senFrac = maxRank > 0 ? rank / maxRank : 0;
 
   const jfScore = jfRange.min + (jfRange.max - jfRange.min) * senFrac;
-  const senScore = senFrac;
   const skillScore = Math.min(row.skill_count || 0, skill_cap || 5) / (skill_cap || 5);
 
   const wJf = weightFor("jf");
-  const wSen = weightFor("seniority");
   const wSkill = weightFor("skills");
 
-  let total = wJf * jfScore + wSen * senScore + wSkill * skillScore;
+  let total = wJf * jfScore + wSkill * skillScore;
 
   // 1P signal factors — norm columns are pre-normalised 0–1 in data.csv.
   const oneP = [];
@@ -69,7 +67,7 @@ function scoreRow(row, config) {
     oneP.push({ sig, w, norm, raw });
   }
 
-  return { total, jfScore, senScore, skillScore, wJf, wSen, wSkill, jfRange, oneP };
+  return { total, jfScore, skillScore, wJf, wSkill, jfRange, oneP };
 }
 
 function fmtScore(s) {
@@ -363,12 +361,6 @@ function renderBreakdown(row, s) {
       weight: s.wJf,
     },
     {
-      factor: `Seniority — ${row.job_level || "—"}`,
-      detail: `rank ${row.job_level_rank || 0} / ${row.max_job_level_rank || 19}`,
-      score: s.senScore,
-      weight: s.wSen,
-    },
-    {
       factor: `Skills — ${row.skill_count || 0} matched`,
       detail: (row.matched_skills || "none"),
       score: s.skillScore,
@@ -467,11 +459,16 @@ function fmtW(v) {
 
 function renderWeightSliders() {
   const container = document.getElementById("weight-sliders");
+  // Keep the job-function range sliders alive across re-renders: if a prior
+  // render nested them inside this container, park them outside before we wipe.
+  const jfSliders = document.getElementById("jf-range-sliders");
+  if (jfSliders && jfSliders.parentElement === container) container.after(jfSliders);
   container.innerHTML = "";
   for (const [key, spec] of Object.entries(_config.weights)) {
     const val = spec.current ?? spec.default;
     const div = document.createElement("div");
     div.className = "weight-slider-row";
+    div.id = "weight-row-" + key;
     div.innerHTML = `
       <div class="slider-label">
         <span>${esc(spec.label)}</span>
@@ -510,6 +507,32 @@ function renderWeightSliders() {
         _config.weights[key].current ?? _config.weights[key].default ?? 0
       );
     });
+  }
+  // Put the per-function Min/Max range sliders directly under the Job Function
+  // weight row, collapsed behind a disclosure arrow ON that row (so the ranges
+  // read as a detail of the Job Function weight — no separate heading).
+  const jfRow = document.getElementById("weight-row-jf");
+  if (jfRow && jfSliders) {
+    jfRow.after(jfSliders);
+    jfSliders.style.marginLeft = "12px";
+    jfSliders.style.display = "none"; // collapsed by default
+    const labelSpan = jfRow.querySelector(".slider-label > span");
+    if (labelSpan && !labelSpan.querySelector(".jf-disclosure")) {
+      const arrow = document.createElement("button");
+      arrow.type = "button";
+      arrow.className = "jf-disclosure";
+      arrow.textContent = "▶";
+      arrow.title = "Show/hide per-function score ranges";
+      arrow.style.cssText =
+        "background:none;border:none;cursor:pointer;padding:0;" +
+        "margin-right:4px;font-size:10px;color:#64748b;line-height:1;";
+      arrow.addEventListener("click", () => {
+        const show = jfSliders.style.display === "none";
+        jfSliders.style.display = show ? "" : "none";
+        arrow.textContent = show ? "▼" : "▶";
+      });
+      labelSpan.prepend(arrow, " ");
+    }
   }
 }
 

--- a/skills/sumble-people-scoring/example/static/index.html
+++ b/skills/sumble-people-scoring/example/static/index.html
@@ -31,11 +31,9 @@
       <p class="panel-sub">Weights must sum to 100%.</p>
       <div id="weight-sliders"></div>
 
-      <details class="accordion" id="jf-accordion">
-        <summary>Job function ranges</summary>
-        <p class="panel-sub">Min score @ IC · Max score @ CXO.</p>
-        <div id="jf-range-sliders"></div>
-      </details>
+      <!-- Job-function Min/Max range sliders — app.js moves this directly under
+           the "Job Function (%)" weight row (no separate accordion/heading). -->
+      <div id="jf-range-sliders"></div>
 
       <button id="save-btn" class="btn-primary">Save weights</button>
       <button id="download-btn" class="btn-link">Download score sheet</button>

--- a/skills/sumble-people-scoring/template/config.json
+++ b/skills/sumble-people-scoring/template/config.json
@@ -6,64 +6,107 @@
   "name_column": "name",
   "linkedin_url_column": "linkedin_url",
   "sumble_url_column": "sumble_url",
-
   "account_picker": {
     "domain_column": "domain",
     "org_name_column": "org_name"
   },
-
   "table_columns": [
-    "name", "current_title", "job_function_name", "job_level",
-    "matched_skills", "skill_count", "location"
+    "name",
+    "current_title",
+    "job_function_name",
+    "job_level",
+    "matched_skills",
+    "skill_count",
+    "location"
   ],
-
   "weights": {
-    "jf":        { "default": 38, "current": 38, "min": 0, "max": 100, "label": "Job Function (%)" },
-    "seniority": { "default": 46, "current": 46, "min": 0, "max": 100, "label": "Seniority (%)" },
-    "skills":    { "default": 16, "current": 16, "min": 0, "max": 100, "label": "Skills (%)" }
+    "jf": {
+      "default": 70.37,
+      "current": 70.37,
+      "min": 0,
+      "max": 100,
+      "label": "Job Function (%)"
+    },
+    "skills": {
+      "default": 29.63,
+      "current": 29.63,
+      "min": 0,
+      "max": 100,
+      "label": "Skills (%)"
+    }
   },
-
   "job_function_ranges": {
-    "sales":                          { "min": 0.50, "max": 0.90, "label": "Sales" },
-    "account-executive":              { "min": 0.50, "max": 0.90, "label": "Account Executive" },
-    "sales-development-representative": { "min": 0.30, "max": 0.70, "label": "SDR" },
-    "revenue-operations":             { "min": 0.60, "max": 0.95, "label": "Revenue Operations" },
-    "marketing":                      { "min": 0.55, "max": 0.90, "label": "Marketing" }
+    "sales": {
+      "min": 0.5,
+      "max": 0.9,
+      "label": "Sales"
+    },
+    "account-executive": {
+      "min": 0.5,
+      "max": 0.9,
+      "label": "Account Executive"
+    },
+    "sales-development-representative": {
+      "min": 0.3,
+      "max": 0.7,
+      "label": "SDR"
+    },
+    "revenue-operations": {
+      "min": 0.6,
+      "max": 0.95,
+      "label": "Revenue Operations"
+    },
+    "marketing": {
+      "min": 0.55,
+      "max": 0.9,
+      "label": "Marketing"
+    }
   },
-
-  "default_jf_range": { "min": 0.50, "max": 0.85 },
-
+  "default_jf_range": {
+    "min": 0.5,
+    "max": 0.85
+  },
   "skill_cap": 5,
-
   "seniority": {
-    "rank_column":     "job_level_rank",
+    "rank_column": "job_level_rank",
     "max_rank_column": "max_job_level_rank"
   },
-
   "one_p_signals": [],
-
   "flags": {
     "crm_contact_column": "is_crm_contact",
     "gold_column": "is_icp_gold"
   },
-
   "icp": {
-    "_comment": "Self-contained ICP definition — the ACTUAL slugs (not just counts) so a coding agent can re-implement the score without re-deriving the ICP. skill_score counts a person's technologies present in icp.skills; the ICP population is icp.job_functions at/above icp.seniority_floor.rank.",
+    "_comment": "Self-contained ICP definition \u2014 the ACTUAL slugs (not just counts) so a coding agent can re-implement the score without re-deriving the ICP. skill_score counts a person's technologies present in icp.skills; the ICP population is icp.job_functions at/above icp.seniority_floor.rank.",
     "job_functions": [
-      { "slug": "sales", "name": "Sales" },
-      { "slug": "revenue-operations", "name": "Revenue Operations" }
+      {
+        "slug": "sales",
+        "name": "Sales"
+      },
+      {
+        "slug": "revenue-operations",
+        "name": "Revenue Operations"
+      }
     ],
     "skills": [
-      { "slug": "salesforce", "name": "Salesforce" },
-      { "slug": "outreach", "name": "Outreach" }
+      {
+        "slug": "salesforce",
+        "name": "Salesforce"
+      },
+      {
+        "slug": "outreach",
+        "name": "Outreach"
+      }
     ],
-    "seniority_floor": { "label": "Manager and above", "rank": 4 }
+    "seniority_floor": {
+      "label": "Manager and above",
+      "rank": 4
+    }
   },
-
   "filters_applied": {
-    "seniority_floor_label":    "Manager and above",
-    "seniority_floor_rank":     4,
-    "icp_job_function_count":   21,
-    "icp_skill_count":          17
+    "seniority_floor_label": "Manager and above",
+    "seniority_floor_rank": 4,
+    "icp_job_function_count": 21,
+    "icp_skill_count": 17
   }
 }

--- a/skills/sumble-people-scoring/template/score_leads.py
+++ b/skills/sumble-people-scoring/template/score_leads.py
@@ -12,7 +12,6 @@ people-scoring-weights.json -> scoring_formula):
     seniority_frac  = job_level_rank / max_job_level_rank
     jf_score        = jf_range[slug].min
                       + (jf_range[slug].max - jf_range[slug].min) * seniority_frac
-    seniority_score = seniority_frac
     skill_score     = min(skill_count, skill_cap) / skill_cap
     <signal>_score  = <signal>_norm        (already 0-1)
     people_score    = Σ (weight_pct/100) * factor_score      # lands in [0, 1]
@@ -86,7 +85,6 @@ def score_row(row: dict[str, Any], spec: dict[str, Any]) -> dict[str, float]:
 
     factor_scores: dict[str, float] = {
         "jf": jf_score,
-        "seniority": sen_frac,
         "skills": skill_score,
     }
     # 1P signals contribute their pre-normalised <norm_column> value directly.
@@ -135,7 +133,7 @@ def main() -> int:
     if args.top > 0:
         scored = scored[: args.top]
 
-    extra_cols = ["rank", "people_score", "jf_score", "seniority_score", "skills_score"]
+    extra_cols = ["rank", "people_score", "jf_score", "skills_score"]
     extra_cols += [f"{(s.get('weight_key') or s.get('key'))}_score"
                    for s in spec["one_p_signals"]]
     base_cols = list(rows[0].keys())

--- a/skills/sumble-people-scoring/template/score_sheet.py
+++ b/skills/sumble-people-scoring/template/score_sheet.py
@@ -21,7 +21,6 @@ and at startup, and the in-app Download button serves the same sheet.
 The score mirrors the app's client math and score_leads.py exactly:
   seniority_frac  = job_level_rank / max_job_level_rank
   jf_score        = jf_range.min + (jf_range.max - jf_range.min) * seniority_frac
-  seniority_score = seniority_frac
   skill_score     = min(skill_count, skill_cap) / skill_cap
   1p factor       = its pre-normalised <norm_column> value
   people_score    = 100 * Σ (weight_pct/100) * factor_score
@@ -78,7 +77,7 @@ def factor_scores(row: dict, config: dict) -> dict[str, float]:
     cap = config.get("skill_cap", 5) or 5
     skill_score = min(_f(row.get("skill_count")), cap) / cap
 
-    out = {"jf": jf_score, "seniority": sen_frac, "skills": skill_score}
+    out = {"jf": jf_score, "skills": skill_score}
     for sig in config.get("one_p_signals", []) or []:
         key = sig.get("weight_key") or f"1p_{sig.get('key')}"
         out[key] = _f(row.get(sig.get("norm_column") or f"{sig.get('key')}_norm"))

--- a/skills/sumble-people-scoring/template/static/app.js
+++ b/skills/sumble-people-scoring/template/static/app.js
@@ -50,14 +50,12 @@ function scoreRow(row, config) {
   const senFrac = maxRank > 0 ? rank / maxRank : 0;
 
   const jfScore = jfRange.min + (jfRange.max - jfRange.min) * senFrac;
-  const senScore = senFrac;
   const skillScore = Math.min(row.skill_count || 0, skill_cap || 5) / (skill_cap || 5);
 
   const wJf = weightFor("jf");
-  const wSen = weightFor("seniority");
   const wSkill = weightFor("skills");
 
-  let total = wJf * jfScore + wSen * senScore + wSkill * skillScore;
+  let total = wJf * jfScore + wSkill * skillScore;
 
   // 1P signal factors — norm columns are pre-normalised 0–1 in data.csv.
   const oneP = [];
@@ -69,7 +67,7 @@ function scoreRow(row, config) {
     oneP.push({ sig, w, norm, raw });
   }
 
-  return { total, jfScore, senScore, skillScore, wJf, wSen, wSkill, jfRange, oneP };
+  return { total, jfScore, skillScore, wJf, wSkill, jfRange, oneP };
 }
 
 function fmtScore(s) {
@@ -363,12 +361,6 @@ function renderBreakdown(row, s) {
       weight: s.wJf,
     },
     {
-      factor: `Seniority — ${row.job_level || "—"}`,
-      detail: `rank ${row.job_level_rank || 0} / ${row.max_job_level_rank || 19}`,
-      score: s.senScore,
-      weight: s.wSen,
-    },
-    {
       factor: `Skills — ${row.skill_count || 0} matched`,
       detail: (row.matched_skills || "none"),
       score: s.skillScore,
@@ -467,11 +459,16 @@ function fmtW(v) {
 
 function renderWeightSliders() {
   const container = document.getElementById("weight-sliders");
+  // Keep the job-function range sliders alive across re-renders: if a prior
+  // render nested them inside this container, park them outside before we wipe.
+  const jfSliders = document.getElementById("jf-range-sliders");
+  if (jfSliders && jfSliders.parentElement === container) container.after(jfSliders);
   container.innerHTML = "";
   for (const [key, spec] of Object.entries(_config.weights)) {
     const val = spec.current ?? spec.default;
     const div = document.createElement("div");
     div.className = "weight-slider-row";
+    div.id = "weight-row-" + key;
     div.innerHTML = `
       <div class="slider-label">
         <span>${esc(spec.label)}</span>
@@ -510,6 +507,32 @@ function renderWeightSliders() {
         _config.weights[key].current ?? _config.weights[key].default ?? 0
       );
     });
+  }
+  // Put the per-function Min/Max range sliders directly under the Job Function
+  // weight row, collapsed behind a disclosure arrow ON that row (so the ranges
+  // read as a detail of the Job Function weight — no separate heading).
+  const jfRow = document.getElementById("weight-row-jf");
+  if (jfRow && jfSliders) {
+    jfRow.after(jfSliders);
+    jfSliders.style.marginLeft = "12px";
+    jfSliders.style.display = "none"; // collapsed by default
+    const labelSpan = jfRow.querySelector(".slider-label > span");
+    if (labelSpan && !labelSpan.querySelector(".jf-disclosure")) {
+      const arrow = document.createElement("button");
+      arrow.type = "button";
+      arrow.className = "jf-disclosure";
+      arrow.textContent = "▶";
+      arrow.title = "Show/hide per-function score ranges";
+      arrow.style.cssText =
+        "background:none;border:none;cursor:pointer;padding:0;" +
+        "margin-right:4px;font-size:10px;color:#64748b;line-height:1;";
+      arrow.addEventListener("click", () => {
+        const show = jfSliders.style.display === "none";
+        jfSliders.style.display = show ? "" : "none";
+        arrow.textContent = show ? "▼" : "▶";
+      });
+      labelSpan.prepend(arrow, " ");
+    }
   }
 }
 

--- a/skills/sumble-people-scoring/template/static/index.html
+++ b/skills/sumble-people-scoring/template/static/index.html
@@ -28,11 +28,9 @@
       <p class="panel-sub">Weights must sum to 100%.</p>
       <div id="weight-sliders"></div>
 
-      <details class="accordion" id="jf-accordion">
-        <summary>Job function ranges</summary>
-        <p class="panel-sub">Min score @ IC · Max score @ CXO.</p>
-        <div id="jf-range-sliders"></div>
-      </details>
+      <!-- Job-function Min/Max range sliders — app.js moves this directly under
+           the "Job Function (%)" weight row (no separate accordion/heading). -->
+      <div id="jf-range-sliders"></div>
 
       <button id="save-btn" class="btn-primary">Save weights</button>
       <button id="download-btn" class="btn-link">Download score sheet</button>


### PR DESCRIPTION
## Summary

Two improvements to the **sumble-people-scoring** skill (applied to both `template/` and `example/`):

### 1. Nest the job-function ranges under the Job Function weight
The per-function Min@IC / Max@CXO sliders now render directly under the **"Job Function (%)"** weight row, behind a small disclosure arrow (collapsed by default) — instead of a separate "Job function ranges" accordion/heading. They read as a detail of the weight they belong to.

### 2. Drop the double-counting Seniority factor
`jf_score` already interpolates `min@IC → max@CXO` by the person's seniority, so the **Job Function factor is already job-function × seniority**. A separate Seniority factor therefore double-counted seniority.

- Removed the Seniority weight (remaining weights renormalized to 100), its slider, and its per-person breakdown row.
- **Kept** the person's *Level* display (a fact) and the seniority **config** (rank columns) that drives `jf_score`.
- `score_sheet.py` / `score_leads.py` key off `config.weights`, so they stop counting seniority as well; removed the now-dead `seniority_score` output column.

### Note
The public default seniority weight was **46%**, so removing it renormalizes to **jf 70.4 / skills 29.6** — a notable default shift (jf now carries the seniority signal). Tune if that's too jf-heavy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
