### PR TITLE
account-scoring: synthetic tech categories + native same-scope concentration

### DIFF
--- a/skills/sumble-account-scoring/SKILL.md
+++ b/skills/sumble-account-scoring/SKILL.md
@@ -216,7 +216,7 @@ referenced from `account-scoring-weights.json` so `app.py` is generic.
 - `industry` (str) — `attributes.industry`
 - `employee_count_int` (int) — the org's **exact** headcount, read from the `attributes.employee_count` attribute, which the endpoint now returns as an exact integer (e.g. `2615`). A legacy band string (`"1,001 - 5,000"`) maps to its midpoint via `sumble_v6.emp_band_to_int`; missing → 0.
 - `jobs_count` (int) — org-total job-post count (`attributes.jobs_count`); firmographic.
-- `teams_count` (int) — org-total team count (`attributes.teams_count`); the denominator for tech-team concentration (`{tech}_team_pct = 100 * {tech}_teams / teams_count`).
+- `teams_count` (int) — org-total team count (`attributes.teams_count`); firmographic only. It is **record-scoped** (the matched org alone, not its subsidiaries) so it is NOT used as a concentration denominator — see the concentration note under "ICP signal columns".
 
 **CRM linkage:**
 - `crm_account_id` (str, nullable) — internal CRM / Salesforce id, carried through from `_raw/sample.csv` (Branch A only). Kept in `data.csv` (NOT shown in the app, since duplicated CRM records would surface the same Sumble org multiple times).
@@ -282,9 +282,47 @@ a `flag` column (above) OR membership in the `tags` column.
 slugs):
 - Persona count `{jf}_people` (int); concentration `{jf}_pct` (0–100);
   YoY % growth `{jf}_growth_yoy` (float, e.g. `0.20` = +20%).
-- Tech team counts `{tech}_teams` (int, individual tech or category);
-  tech team concentration `{tech}_team_pct` = `100 * {tech}_teams /
-  NULLIF(organizations.teams_count, 0)` (0–100).
+- Tech team counts `{tech}_teams` (int, any tech kind); tech job posts
+  `{tech}_jobs` (int); tech **hiring** concentration `{tech}_job_pct` (0–100).
+
+  **Concentration comes from the endpoint's NATIVE metrics, not from dividing by
+  an org attribute.** `{jf}_pct` is built on `people_concentration` (job_function
+  entities) and `{tech}_job_pct` on `job_post_concentration` (advanced_query
+  entities). Both sides of those ratios are hierarchy rollups, so the scope
+  mismatch that used to break parent orgs cannot arise: Advance returns 252
+  Design teams / 645 Design job posts across its subsidiaries against a
+  record-scoped `teams_count` of 6, which as a naive ratio read "4200% of teams".
+  Note this makes tech concentration a share of **hiring**, not of teams —
+  `job_post_concentration` is the only concentration metric `advanced_query`
+  exposes, and it is the same measure as the product's own concentration sort.
+
+  **Reported as the Wilson 95% lower confidence bound** (`sumble_v6._share`,
+  `CONFIDENCE_Z=1.96`) — the lowest share that could plausibly explain what was
+  observed. A raw ratio scores 1/1 and 900/900 identically at "100%", so orgs we
+  know almost nothing about saturate the signal: on a 4,884-row pull 192 orgs
+  read ≥99% design share with a MEDIAN denominator of **1**. The p99 normaliser
+  then fits to those and a well-measured org's genuine 7% share normalises to
+  ~0.07 — the signal ends up ranking how LITTLE data an org has. The bound
+  shrinks thin evidence toward 0 (1/1 → 21%, 9/9 → 70%) while leaving
+  well-measured orgs essentially alone (266/3630 → 6.5%, raw 7.3%). **Don't
+  recommend "raise the Concentration slider" without checking the denominator
+  distribution first.**
+
+  **Denominator recovery is a known WORKAROUND** (`sumble_v6.recover_total`,
+  mirrored in `score_accounts.recover_totals`). The concentration metrics return
+  a ratio only, but the Wilson bound needs the sample size, so the denominator is
+  inverted out: `denominator = count / ratio`. The ratio is rounded to 4dp, so
+  precision degrades as the share shrinks (at a 0.02% share the recovered total
+  is ~25% off; below ~0.005% the ratio rounds to `0.0` and is unrecoverable).
+  Every persona shares ONE org-wide denominator and every tech shares ONE, so it
+  is recovered a single time per org from the LARGEST count available and reused
+  — a tech with 500 posts at `0.0250` pins the total to 20,000 ±0.2%. The
+  recovered totals are kept as `people_total_est` / `jobs_total_est` so any share
+  is auditable against the counts beside it. **Delete this once
+  `/v6/organizations` exposes hierarchy-scoped counts as attributes**
+  (`hp_jobs_count` / `hp_people_count` / `hp_teams_count` already exist on the
+  `organizations` table; flagged to the API team) — then numerator and
+  denominator both arrive directly, at full precision.
 
 **Buying-window columns** (always present) — one per key project:
 `{project}_x_relevant_tech_jobposts` (Template C5). The relevant tech set
@@ -403,31 +441,59 @@ the last time it was shown, re-print the whole updated list, not a diff.
    user confirms the FINAL shape, not raw techs that change in Stage 2a.**
    First snap every proposed tech to its slug (`SearchTechnologies`), then run
    the category roll-up (the procedure + SQL in Stage 2a → "Roll individual
-   techs up into predefined categories"). Present the ICP with the rolled-up
-   **categories** in place of their absorbed individual techs (showing each
-   category's coverage% and the techs it absorbs), and the unabsorbed techs as
-   individuals. This is just early invocation of the Stage 2a logic; Stage 2a
-   then only persists the already-confirmed result to `spec.json`.
+   techs up into predefined categories"), then the grouping pass (Stage 2a →
+   "Group every tech"). Present the ICP with **categories** in place of their
+   absorbed individual techs (showing each category's coverage% and the techs it
+   absorbs). This is just early invocation of the Stage 2a logic; Stage 2a then
+   only persists the already-confirmed result to `spec.json`.
+
+   **Present GROUPS, not a pile of individual techs.** Every proposed tech
+   should arrive inside a predefined or synthetic category; a standalone tech is
+   the exception you justify, not the default (Stage 2a → "Group every tech"
+   has the ordering). Sparse niche techs scored one-by-one mostly read 0 and
+   double-count the same team across signals.
+
+   **When no predefined category fits, author a SYNTHETIC one** (Stage 2a →
+   "Synthetic categories") — an ICP-specific grouping scored as one deduped
+   `team_count`. This is the common case for niche ICPs, where the
+   competitor/practitioner tools are individually sparse and Sumble has no
+   category for them. A synthetic category can **absorb a whole predefined
+   category** (`member_categories`) and extend it with extra slugs (`members`) —
+   the right move when a predefined category is close but incomplete. It may
+   also pull in **relevant techs the original ICP list never mentioned** (that's
+   the point — you're defining the capability, not just regrouping) — so
+   discover them first (`SearchTechnologies` / a `technologies` query for
+   mention volume), then obey the guardrails in Stage 2a: every member
+   defensibly ICP, no dominating member, each member in exactly one category,
+   `syn-` slug prefix. **Print the FULL membership with per-member mention
+   volume in the confirmation message** — the user approves membership before a
+   single credit is spent.
 
    Present as **ONE** compact markdown summary + a single yes/edit prompt
    (no multi-selects, no per-category questions); loop on edits until
    accepted. **The summary must be COMPLETE — every element of the ICP the
    pipeline will fetch, with nothing elided:** all personas with key/other
-   tiers; every technology category with its coverage% and the full list of
-   absorbed techs; every individual tech with its tier; every project; and
+   tiers; every predefined technology category with its coverage% and the full
+   list of absorbed techs; every synthetic category with its COMPLETE
+   membership (absorbed categories AND member slugs); every standalone tech
+   with its tier **and why it was left standalone**; every project; and
    whether funding attributes are scored (`Funding: on/off`, per the funding
    question below). Render it in the message itself (see the Confirmation rule above
    — never rely on question-widget option labels to carry the list). Example:
    ```
    Proposed ICP for <company>:
      • Personas (key): Sales, RevOps · (other): Marketing
-     • Technology categories: Inference & Serving (31% — absorbs vllm,
-       baseten, modal, replicate)
-     • Technologies (individual): clay (key), common-room (key),
-       hg-insights (other), zoominfo (other)
+     • Technology categories (predefined): Inference & Serving (31% — absorbs
+       vllm, baseten, modal, replicate)
+     • Technology categories (synthetic): GTM Data Enrichment (key) — absorbs
+       category Sales Intelligence, plus clay (12K), common-room (3K),
+       apollo-io (9K)
+     • Technologies (standalone): acme-cloud (key) — our own product, kept
+       separate so you can weight existing-usage accounts on their own
      • Projects: Generative AI, Digital Transformation
    Reply "yes", or describe changes (e.g. "drop marketing, add SDR",
-   "split out vllm from Inference & Serving").
+   "split out vllm from Inference & Serving", "drop zoominfo from GTM Data
+   Enrichment — it dominates the category").
    ```
 
    **Also confirm the buying-window combinations**
@@ -840,7 +906,10 @@ broader than the ICP, so prefer the individual techs. Apply the rules:
   category (no double-counting).
 - **Suggest a category** (replace its absorbed individual techs with one
   `{"slug": <cat>, "kind": "category"}` entry) only when it absorbs **≥2** ICP
-  techs. Keep unabsorbed techs as individual `{"slug": …}` entries.
+  techs.
+- **Then sweep up whatever is left — do NOT stop here with a pile of orphan
+  individual techs.** Unabsorbed techs are the *input* to the grouping pass
+  below, not the output. Run "Group every tech" before presenting.
 - Present the proposed rollups as part of the Q2 ICP confirmation (category,
   coverage%, the techs it absorbs) and loop on the user's edits — the user
   confirms categories, not the raw pre-rollup techs.
@@ -850,10 +919,131 @@ pipeline handles `kind: "category"` end to end — the endpoint enrichment
 (`technology_category` + `granularity: aggregate`), the whitespace ranking
 (`technology_category IN`), the score signal, and `score_accounts.py`.
 
+##### Synthetic categories — when no predefined category fits
+
+Sumble's predefined categories are general-purpose; a specific ICP often has no
+category that expresses it (there is no "Offensive Security Tooling" category,
+no "Autonomous Pentest Competitors" category). When the roll-up above yields
+nothing usable — every candidate is below the 2% bar, absorbs <2 ICP techs, or
+is far broader than the ICP — author a **synthetic category** instead:
+
+```json
+{"slug": "syn-offensive-security", "label": "Offensive Security Tooling",
+ "tier": "key", "kind": "synthetic",
+ "members": ["burp-suite", "metasploit", "nmap", "kali-linux"]}
+```
+
+It is sent as an `advanced_query` entity, `technology IN (members)`, read as
+`team_count` — the SAME counter the endpoint uses for a predefined category
+aggregate, so a team using three members still **counts once**. (Verified: for
+Deloitte the four members above sum to 187 team-counts individually but the
+synthetic category returns 79.)
+
+**Why reach for one.** Individual competitor/niche techs are sparse — most orgs
+score 0 on each, so N sparse signals mostly contribute noise and, worse,
+double-count the same team across members. One synthetic category is denser,
+deduped, and reads as the *capability* you actually care about.
+
+**Synthetic vs predefined — the tradeoff flips.** A predefined category counts
+the whole category including techs never in the ICP, which is what
+`icp_coverage_pct` measures. A synthetic category is **100% ICP by
+construction** (you authored every member), so there is no coverage leakage —
+but the breadth judgment moves from Sumble to you. That shifts the risk rather
+than removing it, so:
+
+- **Every member must be defensibly ICP on its own.** If you would not have put
+  the tech in the ICP individually, it does not belong in the category.
+- **Watch for a dominating member — then ask WHY it dominates.** The signal is a
+  deduped union, so a member far more common than the rest largely determines
+  it. Pull `total_mentions` per member; when the largest is ≳10× the median,
+  stop and judge:
+  - **Conceptually broader than the category → drop it.** It drags the signal
+    onto a different population. Putting `sonarqube` (~123K) in a pentest
+    category alongside `pentesting` (~1K) makes the signal track code-quality
+    tooling; `wireshark` (~83K) makes it track network engineering.
+  - **Core to the category → keep it, and say so.** `burp-suite` (~26K) towers
+    over `pentesting` (~1K) but IS the definitive pentest tool — the ratio just
+    reflects how practitioners talk. Note in the confirmation that the category
+    will read roughly as "burp-suite plus a margin", so the user is not
+    surprised when it correlates with that one tech.
+  Volume ratio is the flag; conceptual breadth is the test.
+- **Reject ambiguous slugs.** A synthetic category is a bare `technology IN`
+  list with no disambiguation, so a slug whose name collides with something
+  outside the ICP silently imports the wrong orgs. Check every member's name in
+  isolation and drop the ambiguous ones — e.g. `hydra` (pentest brute-forcer,
+  but also Meta's Python config framework), `nuclei`, `responder`, `sliver`,
+  `intruder`, `cobalt` (the PtaaS vendor vs. the metal/`cobalt-strike`). Prefer
+  the unambiguous long name when one exists (`cobalt-strike` over `cobalt`).
+- **Assign each member to exactly ONE synthetic category** — same
+  no-double-counting discipline as the predefined roll-up. Overlapping
+  categories double-weight the same teams.
+- **Aim for 3–15 members.** Fewer than 3 is just individual techs with extra
+  indirection; a very long tail adds breadth you cannot defend member by member.
+- **Prefix the slug `syn-`** so it cannot collide with a real technology slug
+  (the slug names the `{slug}_teams` / `{slug}_jobs` / `{slug}_job_pct` columns).
+- **Show the FULL member list at Q2 confirmation** — the Confirmation rule
+  applies: print every member of every synthetic category, with each member's
+  mention volume, and let the user add/remove before anything is fetched. The
+  member list is also written into the config's `source.why`, so the score stays
+  auditable afterwards.
+
+##### Group every tech — a standalone individual tech is the LAST resort
+
+**Default to grouping. Do not present a list of orphan individual techs.** A
+lone niche tech is a sparse signal: most orgs read 0, so it contributes mostly
+noise, it burns a slider on something that rarely moves, and several such techs
+silently double-count the same team across signals. Grouping fixes all three at
+once. After the predefined roll-up, take every still-ungrouped tech and resolve
+it in this order — stop at the first that applies:
+
+1. **Fold it into a predefined category you already selected**, if it is a
+   member. Free, maintained by Sumble, no judgment required.
+2. **Extend a selected predefined category with a synthetic one.** When the
+   category is right but incomplete — it covers four of your competitors and
+   misses three — author a synthetic category that absorbs the whole category
+   via `member_categories` and adds the missing slugs via `members`. This is
+   strictly better than hand-expanding the category's members: the signal stays
+   in sync when Sumble adds a technology to that category.
+   ```json
+   {"slug": "syn-gen-image", "label": "Generative Image Generation (extended)",
+    "tier": "key", "kind": "synthetic",
+    "member_categories": ["generative-ai-tools"],
+    "members": ["ideogram-ai", "black-forest-labs", "comfyui", "krea-ai"]}
+   ```
+3. **Author a new synthetic category** grouping the leftovers by the *capability*
+   they represent. **Actively recruit additional techs that belong to that
+   capability even if the ICP never named them** — you are defining a capability,
+   not just regrouping a list. Discover them with `SearchTechnologies` or a
+   `technologies` mention-volume query, then apply the guardrails above.
+4. **Leave it standalone** only when it genuinely stands alone — a tech that is
+   both central to the ICP and not a member of any defensible group. **Your own
+   product is the usual legitimate case** (e.g. `ideogram-ai` for Ideogram):
+   accounts already mentioning you are a distinct signal you may want to see and
+   weight on its own rather than blended into a competitor set. When you leave a
+   tech standalone, **say why in the confirmation message** so the user can
+   overrule it.
+
+Two grouping errors to avoid. **Don't force unlike things together** to satisfy
+the rule — a group must name a capability a buyer would recognize, not "the
+remaining techs". And **don't group away a signal the user wants to steer on**:
+if a tech is one they will plausibly want to up- or down-weight by itself, ask
+before absorbing it.
+
+Prefer a predefined category when one genuinely fits (it is maintained by Sumble
+and needs no judgment); reach for synthetic when none does, or when a predefined
+one is close but incomplete. All three kinds can coexist in one spec.
+
+The pipeline handles `kind: "synthetic"` end to end — enrichment
+(`advanced_query`), the whitespace ranking and the project×tech buying-window
+query (`members` expanded into the `technology IN` list, `member_categories`
+into the `technology_category IN` list), the `/teams` deep link (one OR group
+over both), and `score_accounts.py`.
+
 Write **`_raw/spec.json`** (schema: `template/_build/README.md`). Personas carry
 `{slug, name, tier, label}` (`name` is the endpoint term), techs
-`{slug, label, tier[, kind:"category"]}`, projects `{slug,…}`. Show the resolved
-set back to the user before fetching.
+`{slug, label, tier[, kind:"category"|"synthetic", members:[…],
+member_categories:[…]]}`, projects
+`{slug,…}`. Show the resolved set back to the user before fetching.
 
 #### Stage 2b — Write the input list
 

--- a/skills/sumble-account-scoring/articles/02-build-an-account-score-you-can-prospect-from.md
+++ b/skills/sumble-account-scoring/articles/02-build-an-account-score-you-can-prospect-from.md
@@ -130,9 +130,19 @@ This is the exact formula the skill implements, written so an LLM (or a data tea
 Every account gets a vector of **raw attribute values** `xᵢ(a) ≥ 0`. There are three shapes, all pulled from one call to `POST https://api.sumble.com/v6/organizations`:
 
 - **Counts**: `people_count` for a persona (job function), `team_count` for a technology, `job_post_count` for an intent query. Raw non-negative integers.
-- **Concentrations**: derived ratios, size-neutral:
-  - persona share `= 100 · persona_people / employee_count`
-  - tech share `= 100 · tech_teams / teams_count`
+- **Concentrations**: size-neutral shares, read from the API's own concentration
+  metrics so numerator and denominator always cover the same population (both are
+  rolled up across the org's subsidiaries — dividing by a plain org attribute
+  instead would make a holding company read "4200% of teams"):
+  - persona share, from `people_concentration` (people in the function ÷ people in the org)
+  - tech hiring share, from `job_post_concentration` (matching job posts ÷ all job posts)
+
+  Each is reported as the **Wilson 95% lower confidence bound** rather than the
+  raw ratio — the lowest share consistent with what was observed. A raw ratio
+  scores 1-of-1 and 900-of-900 identically at "100%", which lets barely-measured
+  orgs saturate the attribute and crowd out real ICP accounts; the bound pulls
+  thin evidence toward 0 (1/1 → 21%) and leaves well-measured orgs alone
+  (266/3630 → 6.5%, raw 7.3%).
 - **Growth**: persona `people_count_growth_1y`, returned by the API as a percent (e.g. `50.0`) and stored as a ratio (`× 0.01`). This is the one attribute that can be negative.
 
 Intent attributes are **windowed**: `job_post_count` is filtered to the last ~90 days (`since = run_date − 90d`), recomputed at scoring time so the window tracks *now*, not the build date.

--- a/skills/sumble-account-scoring/template/_build/README.md
+++ b/skills/sumble-account-scoring/template/_build/README.md
@@ -49,7 +49,10 @@ Policy constants are baked into the scripts, not chosen per run.
   "include_funding": true,
   "personas": [{"slug": "sales", "name": "Sales", "label": "Sales", "tier": "key"}],
   "techs":    [{"slug": "clay", "label": "Clay", "tier": "key"},
-               {"slug": "cloud-data-warehouse", "label": "Cloud Data Warehouse", "tier": "key", "kind": "category"}],
+               {"slug": "cloud-data-warehouse", "label": "Cloud Data Warehouse", "tier": "key", "kind": "category"},
+               {"slug": "syn-gtm-enrichment", "label": "GTM Data Enrichment", "tier": "key",
+                "kind": "synthetic", "members": ["clay", "common-room", "apollo-io"],
+                "member_categories": ["sales-intelligence"]}],
   "projects": [{"slug": "generative-ai", "label": "Generative AI"}],
   "universe_filters": {
     "preselect": "auto",
@@ -79,6 +82,56 @@ Policy constants are baked into the scripts, not chosen per run.
   "data_sources": {"crm_list": {"source": "...", "size": 1200}, "gold_list": {"source": "closed_won", "size": 48}}
 }
 ```
+
+### Tech `kind` — three ways to select one ICP tech
+
+All three produce the same column shape (`{slug}_teams`, `{slug}_jobs`,
+`{slug}_job_pct`) and the same metric set; only the query TERM differs.
+`sumble_v6.tech_entity()` is the single mapping, shared by `entity_plan` (what we
+fetch) and `build_weights` (what the config records), so they cannot drift.
+
+Every kind goes out as an **`advanced_query`** entity with
+`["team_count", "job_post_count", "job_post_concentration"]`:
+
+| `kind` | term | notes |
+|---|---|---|
+| *(absent)* | `technology EQ 'slug'` | one individual technology |
+| `"category"` | `technology_category EQ 'slug'` | a **predefined** Sumble category |
+| `"synthetic"` | `technology IN (members)` OR'd with `technology_category IN (member_categories)` | an **authored** grouping |
+
+All three are counted the same way — a DEDUPED count over the matching set, so a
+team using several members of a category counts once.
+
+**Why advanced_query for a predefined category, rather than the
+`technology_category` entity type:** only `advanced_query` supports
+`job_post_concentration`, the same-scope concentration metric the score needs
+(both sides hierarchy rollups, so a parent org cannot exceed 100%). It costs
+nothing semantically — the endpoint implements a `technology_category` aggregate
+by building exactly `technology_category EQ '<slug>'` and running it through the
+same advanced-query counter. A happy side effect: `granularity` disappears
+entirely (it is valid only on the `technology_category` type, and the endpoint
+422s if sent on an `advanced_query`), so `tech_entity` returns None for all kinds.
+
+A synthetic category is the escape hatch for an ICP that no predefined category
+expresses. It is 100% ICP by construction (no coverage leakage), but breadth
+becomes the author's judgment — see SKILL.md → "Synthetic categories" for the
+guardrails (every member defensibly ICP, no dominating member, each member in
+exactly one category, `syn-` slug prefix, full member list confirmed by the
+user).
+
+A synthetic category takes **two kinds of membership**, and may use either or
+both:
+
+- `members` — individual technology slugs.
+- `member_categories` — whole **predefined** categories it absorbs. Use this to
+  *extend* a predefined category rather than restate it: absorbing
+  `generative-ai-tools` and adding four competitor slugs scores the union as one
+  signal, and stays in sync when Sumble later adds a technology to that
+  category. Hand-expanding the category's members instead would freeze it.
+
+Both membership kinds are expanded wherever the parts are needed individually:
+the whitespace ranking clause, the project×tech buying-window query, and the
+`/teams` deep link (`expand_tech_slugs` / `expand_tech_categories`).
 
 `section_plan` is OPTIONAL — omit it to take the default three-segment taxonomy
 verbatim. When present it overrides segment labels/weights (`sections`), the
@@ -130,10 +183,13 @@ company), NOT a fixed default — the example values are illustrative only.
 
 - `api_supported:true` — reproducible from `POST /v6/organizations`: persona
   counts (`people_count`), persona YoY growth (`people_count_growth_1y`), tech
-  team counts (`team_count`), 3-month intent (`advanced_query` + `since`),
-  persona concentration (`people_count ÷ employee_count`, exact integer), and
-  **tech concentration** (`{tech}_team_pct` = `team_count ÷ teams_count`, the
-  org-total team count attribute).
+  team counts (`team_count`), tech job posts (`job_post_count`), 3-month intent
+  (`advanced_query` + `since`), and both **concentrations** — persona
+  (`{jf}_pct`, from the native `people_concentration`) and tech hiring
+  (`{tech}_job_pct`, from the native `job_post_concentration`). Each
+  concentration is reported as the Wilson 95% lower bound over a denominator
+  recovered from the ratio; see `sumble_v6.recover_total` for why that recovery
+  is a temporary workaround.
 - `api_supported:false` — **first-party signals only** (joined by account, not
   from Sumble). The portable `score_accounts.py` drops these and re-normalises
   the remaining weights.

--- a/skills/sumble-account-scoring/template/_build/build_weights.py
+++ b/skills/sumble-account-scoring/template/_build/build_weights.py
@@ -71,7 +71,7 @@ DEFAULT_CATEGORY_SECTION = {
     "intent_project_tech_count": "size",
     "funding": "size",
     "icp_persona_concentration": "concentration",
-    "relevant_tech_team_concentration": "concentration",
+    "relevant_tech_job_concentration": "concentration",
     "icp_persona_growth": "growth_momentum",
     "funding_momentum": "growth_momentum",
 }
@@ -91,8 +91,8 @@ CATEGORY_META = {
         "label": "Persona concentration",
         "default_pct": 60.0,
     },
-    "relevant_tech_team_concentration": {
-        "label": "Tech team concentration",
+    "relevant_tech_job_concentration": {
+        "label": "Tech hiring concentration",
         "default_pct": 40.0,
     },
     "icp_persona_growth": {"label": "Persona growth (YoY)", "default_pct": 100.0},
@@ -106,7 +106,7 @@ CATEGORY_META = {
 CATEGORY_CLONE_FROM = {
     "icp_persona_concentration": "icp_persona_count",
     "icp_persona_growth": "icp_persona_count",
-    "relevant_tech_team_concentration": "relevant_tech_team_count",
+    "relevant_tech_job_concentration": "relevant_tech_team_count",
 }
 
 
@@ -148,20 +148,37 @@ def compute_p99(values: list[float], transform: str) -> float:
     return round(max(xs[idx], 1e-9), 6)
 
 
-def _entity(etype: str, term: str, metric: str, since: str | None = None) -> dict:
+def _entity(
+    etype: str,
+    term: str,
+    metric: str,
+    since: str | None = None,
+    granularity: str | None = None,
+) -> dict:
     ent: dict = {"type": etype, "term": term, "metrics": [metric]}
     if since:
         ent["since"] = since
+    # The endpoint REQUIRES granularity for technology_category (and rejects it
+    # for every other type), so it has to survive into the config — score_accounts
+    # replays these blocks verbatim and would 422 without it.
+    if granularity:
+        ent["granularity"] = granularity
     return ent
 
 
-def _api_block(etype: str, term: str, metric: str, since: str | None = None) -> dict:
+def _api_block(
+    etype: str,
+    term: str,
+    metric: str,
+    since: str | None = None,
+    granularity: str | None = None,
+) -> dict:
     """A `source.api` block: the endpoint, the `select` entity to send, the
     metric to read, and a human-readable extract path. `since` (when present)
     is a 3-month window the scorer recomputes to (run date − 3 months)."""
     block: dict = {
         "endpoint": ENDPOINT,
-        "select_entity": _entity(etype, term, metric, since),
+        "select_entity": _entity(etype, term, metric, since, granularity),
         "read": metric,
         "extract": f"organizations[].entities[type={etype!r},term={term!r}].{metric}",
     }
@@ -174,11 +191,13 @@ def _attr_input(name: str, attribute: str, read: str) -> dict:
     return {"name": name, "endpoint": ENDPOINT, "select_attribute": attribute, "read": read}
 
 
-def _entity_input(name: str, etype: str, term: str, metric: str) -> dict:
+def _entity_input(
+    name: str, etype: str, term: str, metric: str, granularity: str | None = None
+) -> dict:
     return {
         "name": name,
         "endpoint": ENDPOINT,
-        "select_entity": _entity(etype, term, metric),
+        "select_entity": _entity(etype, term, metric, granularity=granularity),
         "read": metric,
     }
 
@@ -203,8 +222,10 @@ def main() -> None:
     techs_key = [t for t in techs if t.get("tier") != "other"]
     techs_other = [t for t in techs if t.get("tier") == "other"]
     techs_all = techs_key + techs_other
-    tech_tool_slugs = [t["slug"] for t in techs if t.get("kind") != "category"]
-    tech_cat_slugs = [t["slug"] for t in techs if t.get("kind") == "category"]
+    # Individual slugs for the intent deep link — a synthetic category
+    # contributes its MEMBERS (the page filters on real technologies).
+    tech_tool_slugs = sumble_v6.expand_tech_slugs(techs)
+    tech_cat_slugs = sumble_v6.expand_tech_categories(techs)
     since = sumble_v6.since_3mo()
 
     persona_decay = decay_weights(len(personas))
@@ -361,16 +382,27 @@ def main() -> None:
                 "why": f"Concentration filters out big orgs with a {label} per division.",
                 "kind": "sumble_derived",
                 "derivation": {
-                    "formula": f"100 * {slug}_people / employee_count_int",
+                    "formula": (
+                        f"wilson_lb_pct({slug}_people, "
+                        f"round({slug}_people / {slug}_people_conc))"
+                    ),
+                    "note": (
+                        "people_concentration is the endpoint's native same-scope "
+                        "share (people in function / people in org, both hierarchy "
+                        "rollups). It returns a ratio only, so the denominator is "
+                        "recovered by inversion — once per org from the persona with "
+                        "the largest headcount — and the reported value is the Wilson "
+                        "95% lower bound so a 1-of-1 org cannot read 100%."
+                    ),
                     "inputs": [
                         _entity_input(
                             f"{slug}_people", "job_function", name, "people_count"
                         ),
-                        _attr_input(
-                            "employee_count_int",
-                            "employee_count",
-                            "exact org headcount (employee_count is an integer; "
-                            "legacy band strings map to a midpoint)",
+                        _entity_input(
+                            f"{slug}_people_conc",
+                            "job_function",
+                            name,
+                            "people_concentration",
                         ),
                     ],
                 },
@@ -410,10 +442,30 @@ def main() -> None:
     # deep-link field differ, but the column/score shape is identical.
     for idx, t in enumerate(techs_all):
         slug, label = t["slug"], t["label"]
-        is_cat = t.get("kind") == "category"
-        etype = "technology_category" if is_cat else "technology"
-        link_field = "technology_category" if is_cat else "technology"
-        kind_word = "category" if is_cat else "tool"
+        kind = t.get("kind")
+        ent = sumble_v6.tech_entity(t)
+        etype, eterm, egran = ent["type"], ent["term"], ent["granularity"]
+        if kind == "synthetic":
+            # Authored membership — deep-link on the members themselves (one OR
+            # group), and name them in `why` so the score stays auditable.
+            members = sumble_v6.tech_members(t)
+            member_cats = sumble_v6.tech_member_categories(t)
+            link_filters = {}
+            if members:
+                link_filters["technology"] = members
+            if member_cats:
+                link_filters["technology_category"] = member_cats
+            kind_word = "category"
+            why = (
+                f"Teams using any of the {label} category "
+                f"({', '.join(members + member_cats)}) prove active, "
+                "in-production adoption."
+            )
+        else:
+            link_field = "technology_category" if kind == "category" else "technology"
+            link_filters = {link_field: [slug]}
+            kind_word = "category" if kind == "category" else "tool"
+            why = f"Teams using the {label} {kind_word} prove active, in-production adoption."
         add_signal(
             key=f"relevant_tech_team_count_{slug}",
             column=f"{slug}_teams",
@@ -423,35 +475,50 @@ def main() -> None:
             within=tech_decay[idx],
             api_supported=True,
             source={
-                "why": f"Teams using the {label} {kind_word} prove active, in-production adoption.",
+                "why": why,
                 "kind": "sumble_api",
-                "api": _api_block(etype, slug, "team_count"),
+                "api": _api_block(etype, eterm, "team_count", granularity=egran),
             },
-            sumble_link={"path": "/teams", "filters": {link_field: [slug]}},
+            sumble_link={"path": "/teams", "filters": link_filters},
         )
         add_signal(
-            key=f"relevant_tech_team_concentration_{slug}",
-            column=f"{slug}_team_pct",
-            label=f"{label} team share",
-            category="relevant_tech_team_concentration",
+            key=f"relevant_tech_job_concentration_{slug}",
+            column=f"{slug}_job_pct",
+            label=f"{label} share of hiring",
+            category="relevant_tech_job_concentration",
             transform="linear",
             within=tech_decay[idx],
             api_supported=True,
             source={
-                "why": f"% of teams using {label} signals broad vs one-team adoption.",
+                "why": f"% of hiring mentioning {label} signals broad vs one-team adoption.",
                 "kind": "sumble_derived",
                 "derivation": {
-                    "formula": f"100 * {slug}_teams / teams_count",
+                    "formula": (
+                        f"wilson_lb_pct({slug}_jobs, round({slug}_jobs / {slug}_jobs_conc))"
+                    ),
+                    "note": (
+                        "job_post_concentration is the endpoint's native same-scope "
+                        "share (matching job posts / all job posts, both hierarchy "
+                        "rollups). It returns a ratio only, so the denominator is "
+                        "recovered by inversion — once per org from the tech with the "
+                        "most job posts — and the reported value is the Wilson 95% "
+                        "lower bound so a 1-of-1 org cannot read 100%."
+                    ),
                     "inputs": [
-                        _entity_input(f"{slug}_teams", etype, slug, "team_count"),
-                        _attr_input(
-                            "teams_count",
-                            "teams_count",
-                            "org-total team count (concentration denominator)",
+                        _entity_input(
+                            f"{slug}_jobs", etype, eterm, "job_post_count", granularity=egran
+                        ),
+                        _entity_input(
+                            f"{slug}_jobs_conc",
+                            etype,
+                            eterm,
+                            "job_post_concentration",
+                            granularity=egran,
                         ),
                     ],
                 },
             },
+            sumble_link={"path": "/jobs", "filters": link_filters},
         )
 
     # Funding signals (only when requested). Modelled as single-input attribute
@@ -681,8 +748,16 @@ def main() -> None:
             ),
             "api_supported": (
                 "true if score_accounts.py can reproduce the column from the public API. "
-                "false (tech concentration) stays in the app for tuning but is dropped + "
-                "weight-renormalised by the portable scorer."
+                "false (first-party signals only) stays in the app for tuning but is "
+                "dropped + weight-renormalised by the portable scorer."
+            ),
+            "concentration": (
+                "Concentration columns come from the endpoint's native same-scope "
+                "metrics (people_concentration / job_post_concentration), reported as "
+                "the Wilson 95% lower bound over a denominator recovered as "
+                "count / ratio — recovered once per org from the largest count. See "
+                "sumble_v6.recover_total; that recovery is a temporary workaround "
+                "pending hierarchy-scoped count attributes on /v6/organizations."
             ),
         },
         "saved_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),

--- a/skills/sumble-account-scoring/template/_build/merge_data.py
+++ b/skills/sumble-account-scoring/template/_build/merge_data.py
@@ -322,6 +322,22 @@ def main() -> None:
         f"Built {len(all_rows)} matched rows ({len(gold_rows)} gold). "
         f"Calibration emitted {len(multipliers_defaults)} multipliers."
     )
+    # Concentration comes from the endpoint's native same-scope metrics, whose
+    # denominator is recovered by inversion (sumble_v6.recover_total). Surface
+    # the rows where it could not be recovered at all — their shares read 0.
+    n_no_den = sum(
+        1
+        for r in all_rows
+        if str(r.get("people_total_est", "0")) in ("0", "0.0")
+        and str(r.get("jobs_total_est", "0")) in ("0", "0.0")
+    )
+    if n_no_den:
+        pct = 100.0 * n_no_den / len(all_rows) if all_rows else 0.0
+        print(
+            f"No concentration denominator recoverable for {n_no_den} row(s) "
+            f"({pct:.1f}%) — no measured persona/tech presence to invert; "
+            "their _pct columns read 0."
+        )
     print(f"Wrote {data_csv}")
 
 

--- a/skills/sumble-account-scoring/template/_build/sumble_v6.py
+++ b/skills/sumble-account-scoring/template/_build/sumble_v6.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import getpass
+import math
 import os
 import re
 import sys
@@ -160,11 +161,159 @@ def _in_list(values: list[str]) -> str:
     return "(" + ", ".join(_q(v) for v in values) + ")"
 
 
+# z for the Wilson score interval (see `_share`). 1.96 = 95% confidence — the
+# standard choice, not tuned per run. Raise to 2.58 (99%) if a pull's thin-data
+# tail still saturates the p99 normaliser.
+CONFIDENCE_Z = 1.96
+
+
+def _share(numerator: float, denominator: float) -> float:
+    """Concentration percentage as the WILSON 95% lower confidence bound.
+
+    Plain English: the lowest share that could plausibly explain what we
+    observed. 1 team of 1 using the tech is consistent with a company that's
+    only ~21% concentrated, so it scores 21 — while 266 of 3630 is pinned tight
+    and scores 6.5, essentially its raw 7.3%.
+
+    Why not the raw ratio: it treats 1/1 and 900/900 as identically "100%", so
+    orgs we know almost nothing about saturate the signal. On a 4,884-row pull
+    192 orgs read >=99% design share with a MEDIAN denominator of 1; the p99
+    normaliser then fits to those and a well-measured org's genuine 7% share
+    normalises to ~0.07 — the signal ends up ranking how LITTLE data an org has.
+    The lower bound shrinks thin evidence toward 0 and leaves well-measured orgs
+    essentially untouched, with one standard constant instead of a tuned prior.
+
+    Deliberately conservative: every share reads slightly below its raw value.
+    That's uniform enough not to disturb ranking among well-measured orgs.
+    """
+    if numerator <= 0 or denominator <= 0:
+        return 0.0
+    # max() guards the rounding artifacts of a recovered denominator (see
+    # `recover_total`); a proportion above 1 is not meaningful.
+    z, n = CONFIDENCE_Z, max(denominator, numerator)
+    p = numerator / n
+    z2 = z * z
+    lb = (
+        p + z2 / (2 * n) - z * math.sqrt(p * (1 - p) / n + z2 / (4 * n * n))
+    ) / (1 + z2 / n)
+    return round(max(100.0 * lb, 0.0), 3)
+
+
+def recover_total(pairs: list[tuple[float, float]]) -> float:
+    """Recover the org-wide concentration DENOMINATOR from (count, ratio) pairs.
+
+    WORKAROUND — delete once /v6/organizations exposes hierarchy-scoped counts
+    as attributes (`hp_jobs_count` / `hp_people_count` / `hp_teams_count` already
+    exist on the `organizations` table; flagged to the API team). The endpoint
+    returns `people_concentration` / `job_post_concentration` as a RATIO only, but
+    the Wilson bound in `_share` needs the sample size, so we invert:
+    `denominator = count / ratio`.
+
+    The ratio is rounded to 4dp, so precision degrades as the share gets small
+    (at a 0.02% share the recovered total is ~25% off; below ~0.005% the ratio
+    rounds to 0.0 and is unrecoverable). Every persona shares ONE denominator
+    (org-wide people) and every tech shares ONE denominator (org-wide job posts),
+    so we recover it a single time from the pair with the LARGEST count — the
+    best-conditioned one available — and reuse it across all signals. A tech with
+    500 posts at 0.0250 pins the total to 20,000 +/-0.2%.
+
+    Returns 0.0 when nothing is recoverable (every count 0, or every ratio
+    rounded away). `_share` then reads 0.0, which is the right answer in both
+    cases: no measured presence, or a share too small to register.
+    """
+    best_total = 0.0
+    best_count = 0.0
+    for count, ratio in pairs:
+        if count > best_count and ratio > 0:
+            best_count = count
+            best_total = count / ratio
+    return round(best_total)
+
+
+def tech_members(t: dict) -> list[str]:
+    """Member technology slugs of a SYNTHETIC category (kind == 'synthetic').
+
+    A synthetic category is an agent-authored set treated as ONE deduped signal,
+    used when no *predefined* Sumble technology_category expresses the ICP
+    grouping. `members` are individual technology slugs; a synthetic category may
+    ALSO absorb whole predefined categories via `member_categories`.
+    """
+    return [str(s) for s in (t.get("members") or [])]
+
+
+def tech_member_categories(t: dict) -> list[str]:
+    """Predefined technology_category slugs absorbed by a SYNTHETIC category.
+
+    Lets a synthetic category extend a predefined one rather than restate it:
+    `member_categories: ["generative-ai-tools"]` plus `members: [...]` scores the
+    whole category OR the extra slugs as a single deduped signal. Absorbing the
+    category (instead of hand-expanding its members) keeps the signal in sync
+    when Sumble later adds a technology to that category.
+    """
+    return [str(s) for s in (t.get("member_categories") or [])]
+
+
+def synthetic_tech_query(t: dict) -> str:
+    """DSL term for a synthetic category, e.g. `technology IN ('a', 'b')` or
+    `(technology IN ('a') OR technology_category IN ('c'))`.
+
+    Sent as an `advanced_query` entity. Its `team_count` is the DEDUPED count of
+    teams using ANY member — the same counter the endpoint uses for a predefined
+    `technology_category` aggregate, so a synthetic category and a predefined one
+    have identical semantics; only the membership is authored rather than looked
+    up. A team using three members still counts once.
+
+    NB: `granularity` is rejected by the endpoint on `advanced_query` (it is
+    valid only for `technology_category`), so `tech_entity` leaves it None — the
+    dedupe is intrinsic to the query, not a granularity setting.
+    """
+    parts = []
+    if tech_members(t):
+        parts.append(f"technology IN {_in_list(tech_members(t))}")
+    if tech_member_categories(t):
+        parts.append(f"technology_category IN {_in_list(tech_member_categories(t))}")
+    if not parts:
+        return ""
+    return parts[0] if len(parts) == 1 else "(" + " OR ".join(parts) + ")"
+
+
+def expand_tech_slugs(techs: list[dict]) -> list[str]:
+    """Every INDIVIDUAL technology slug implied by `techs`, order-preserved and
+    deduped: plain techs plus the members of each synthetic category. Predefined
+    categories are excluded (they live under `technology_category`)."""
+    out: list[str] = []
+    for t in techs:
+        kind = t.get("kind")
+        if kind == "category":
+            continue
+        out.extend(tech_members(t) if kind == "synthetic" else [t["slug"]])
+    seen: set[str] = set()
+    return [s for s in out if not (s in seen or seen.add(s))]
+
+
+def expand_tech_categories(techs: list[dict]) -> list[str]:
+    """Every predefined technology_category slug implied by `techs`, order-preserved
+    and deduped: `kind == 'category'` entries plus the `member_categories` absorbed
+    by each synthetic category."""
+    out: list[str] = []
+    for t in techs:
+        kind = t.get("kind")
+        if kind == "category":
+            out.append(t["slug"])
+        elif kind == "synthetic":
+            out.extend(tech_member_categories(t))
+    seen: set[str] = set()
+    return [s for s in out if not (s in seen or seen.add(s))]
+
+
 def tech_clause(techs: list[dict]) -> str:
-    """DSL clause matching any of the techs — individual slugs via `technology IN`
-    and predefined categories (kind == 'category') via `technology_category IN`."""
-    cats = [t["slug"] for t in techs if t.get("kind") == "category"]
-    indiv = [t["slug"] for t in techs if t.get("kind") != "category"]
+    """DSL clause matching any of the techs — individual slugs via `technology IN`,
+    predefined categories (kind == 'category') via `technology_category IN`, and
+    synthetic categories (kind == 'synthetic') by expanding their member slugs
+    into the individual `technology IN` list and their absorbed
+    `member_categories` into the `technology_category IN` list."""
+    cats = expand_tech_categories(techs)
+    indiv = expand_tech_slugs(techs)
     parts = []
     if indiv:
         parts.append(f"technology IN {_in_list(indiv)}")
@@ -173,6 +322,42 @@ def tech_clause(techs: list[dict]) -> str:
     if not parts:
         return ""
     return parts[0] if len(parts) == 1 else "(" + " OR ".join(parts) + ")"
+
+
+def tech_query(t: dict) -> str:
+    """DSL term matching ONE ICP tech, whichever kind it is:
+      plain      -> `technology EQ 'slug'`
+      category   -> `technology_category EQ 'slug'`
+      synthetic  -> the authored membership union (`synthetic_tech_query`)
+    """
+    kind = t.get("kind")
+    if kind == "synthetic":
+        return synthetic_tech_query(t)
+    if kind == "category":
+        return f"technology_category EQ {_q(t['slug'])}"
+    return f"technology EQ {_q(t['slug'])}"
+
+
+def tech_entity(t: dict) -> dict[str, Any]:
+    """How ONE ICP tech is selected on the endpoint: `{type, term, granularity}`.
+
+    ALL three kinds go out as `advanced_query`, so every tech has one column
+    shape (`{slug}_teams`, `{slug}_jobs`) and one metric set. This is the single
+    place mapping a spec tech to an entity selection, so `entity_plan` (what we
+    fetch) and `build_weights` (what the config records) can never disagree.
+
+    Why advanced_query for a PREDEFINED category too, rather than the
+    `technology_category` type: only `advanced_query` supports
+    `job_post_concentration`, the same-scope concentration metric the score needs
+    (the `technology_category` type does not). It costs nothing semantically —
+    the endpoint implements a `technology_category` aggregate by building exactly
+    `technology_category EQ '<slug>'` and running it through the same
+    advanced-query counter, so the deduped counts are identical.
+
+    `granularity` is None for every kind: it is valid only on the
+    `technology_category` TYPE and the endpoint rejects it on advanced_query.
+    """
+    return {"type": "advanced_query", "term": tech_query(t), "granularity": None}
 
 
 def intent_tech_query(project_slug: str, techs: list[dict]) -> str:
@@ -209,6 +394,19 @@ def entity_plan(spec: dict, since: str | None = None) -> list[dict[str, Any]]:
                 "since": None,
             }
         )
+        # Native same-scope concentration (people in function / people in org,
+        # both hierarchy rollups) — the denominator the score actually needs.
+        # `build_data_row` inverts it to recover that denominator.
+        plan.append(
+            {
+                "col": f"{p['slug']}_people_conc",
+                "type": "job_function",
+                "term": p["name"],
+                "metric": "people_concentration",
+                "scale": 1.0,
+                "since": None,
+            }
+        )
         plan.append(
             {
                 "col": f"{p['slug']}_growth_yoy",
@@ -220,16 +418,36 @@ def entity_plan(spec: dict, since: str | None = None) -> list[dict[str, Any]]:
             }
         )
     for t in techs:
-        is_cat = t.get("kind") == "category"
+        ent = tech_entity(t)
         plan.append(
             {
                 "col": f"{t['slug']}_teams",
-                "type": "technology_category" if is_cat else "technology",
-                "term": t["slug"],
+                **ent,
                 "metric": "team_count",
                 "scale": 1.0,
                 "since": None,
-                "granularity": "aggregate" if is_cat else None,
+            }
+        )
+        # Job posts + their native same-scope concentration. Tech concentration
+        # is a share of HIRING (job posts), not of teams: `job_post_concentration`
+        # is the only concentration metric advanced_query exposes, and both sides
+        # of it are hierarchy-scoped so parent orgs can't blow past 100%.
+        plan.append(
+            {
+                "col": f"{t['slug']}_jobs",
+                **ent,
+                "metric": "job_post_count",
+                "scale": 1.0,
+                "since": None,
+            }
+        )
+        plan.append(
+            {
+                "col": f"{t['slug']}_jobs_conc",
+                **ent,
+                "metric": "job_post_concentration",
+                "scale": 1.0,
+                "since": None,
             }
         )
     if projects:
@@ -327,8 +545,9 @@ def build_data_row(
     # it is a native org tag the endpoint returns in attributes.tags).
     tags = list(attrs.get("tags") or [])
     # employee_count is the endpoint's exact integer headcount (band-string
-    # midpoint only as a legacy fallback). teams_count / jobs_count are org-total
-    # attributes used as concentration denominators and shown as firmographics.
+    # midpoint only as a legacy fallback). teams_count / jobs_count are
+    # record-scoped org attributes, shown as firmographics only — concentration
+    # denominators come from the native concentration metrics instead.
     employee_count = _exact_employee_count(attrs)
     org_teams = int(_f(attrs.get("teams_count")))
     ents = index_entities(resp_row)
@@ -359,22 +578,38 @@ def build_data_row(
         # rather than a hand-built URL.
         row[f"{item['col']}_link"] = ent.get(f"{item['metric']}_url") or ""
 
+    # Concentration signals, from the endpoint's NATIVE concentration metrics.
+    # Both sides of those ratios are hierarchy rollups, so the scope mismatch
+    # that made entity-count / org-attribute shares exceed 100% for holding
+    # companies (Advance: 252 Design teams vs a record-scoped teams_count of 6)
+    # cannot arise. The metrics return a ratio only, so `recover_total` inverts
+    # the best-conditioned one per org to get the denominator `_share` needs.
+    people_total = recover_total(
+        [
+            (_f(row.get(f"{p['slug']}_people")), _f(row.get(f"{p['slug']}_people_conc")))
+            for p in personas
+        ]
+    )
+    # Recovered denominators are kept as columns so a share is always auditable
+    # against the counts beside it.
+    row["people_total_est"] = people_total
     for p in personas:
         people = _f(row.get(f"{p['slug']}_people"))
-        row[f"{p['slug']}_pct"] = (
-            round(100.0 * people / employee_count, 3) if employee_count else 0.0
-        )
+        row[f"{p['slug']}_pct"] = _share(people, people_total)
         # Concentration reuses the persona's /people deep link.
         row[f"{p['slug']}_pct_link"] = row.get(f"{p['slug']}_people_link", "")
-    # Tech team concentration now uses the org-total team count (teams_count
-    # attribute), so it's a true share-of-teams and fully API-reproducible.
+    jobs_total = recover_total(
+        [
+            (_f(row.get(f"{t['slug']}_jobs")), _f(row.get(f"{t['slug']}_jobs_conc")))
+            for t in techs
+        ]
+    )
+    row["jobs_total_est"] = jobs_total
     for t in techs:
-        teams = _f(row.get(f"{t['slug']}_teams"))
-        row[f"{t['slug']}_team_pct"] = (
-            round(100.0 * teams / org_teams, 3) if org_teams else 0.0
-        )
-        # Concentration reuses the tech's /teams deep link.
-        row[f"{t['slug']}_team_pct_link"] = row.get(f"{t['slug']}_teams_link", "")
+        jobs = _f(row.get(f"{t['slug']}_jobs"))
+        row[f"{t['slug']}_job_pct"] = _share(jobs, jobs_total)
+        # Concentration reuses the tech's /jobs deep link (it is a hiring share).
+        row[f"{t['slug']}_job_pct_link"] = row.get(f"{t['slug']}_jobs_link", "")
 
     # Funding columns (only when requested). total/last-round amounts are scored;
     # type/date are display context. Missing values become 0 / "" so the columns

--- a/skills/sumble-account-scoring/template/account-scoring-weights.example.json
+++ b/skills/sumble-account-scoring/template/account-scoring-weights.example.json
@@ -9,9 +9,10 @@
       "first_party": "joined in by account; not from Sumble."
     },
     "api_block": "source.api = {endpoint, select_entity|select_attribute, read, extract}. select_entity is the exact select.entities[] item to send; read is the metric to take off the EntityResult. since entities are a 3-month window the scorer recomputes to (run date \u2212 3 months).",
-    "api_supported": "true if score_accounts.py can reproduce the column from the public API. false (tech concentration) stays in the app for tuning but is dropped + weight-renormalised by the portable scorer."
+    "api_supported": "true if score_accounts.py can reproduce the column from the public API. false (first-party signals only) stays in the app for tuning but is dropped + weight-renormalised by the portable scorer.",
+    "concentration": "Concentration columns come from the endpoint's native same-scope metrics (people_concentration / job_post_concentration), reported as the Wilson 95% lower bound over a denominator recovered as count / ratio \u2014 recovered once per org from the largest count. See sumble_v6.recover_total; that recovery is a temporary workaround pending hierarchy-scoped count attributes on /v6/organizations."
   },
-  "saved_at": "2026-05-31T04:43:19+00:00",
+  "saved_at": "2026-07-22T14:05:05+00:00",
   "customer_name": "Acme \u2014 Scoring",
   "score_label": "Account Score",
   "id_column": "org_id",
@@ -21,91 +22,70 @@
   "data_csv": "data.csv",
   "table_columns": [
     "name",
-    "crm_account_id",
     "url",
     "employee_count_int",
-    "headquarters_country"
+    "__section:acv",
+    "__section:intent"
   ],
-  "data_sources": {
-    "sumble": {
-      "via": "Sumble unified endpoint POST /v6/organizations"
-    },
-    "crm_account_universe": {
-      "included": true,
-      "via": "Salesforce MCP",
-      "object": "Account"
-    },
-    "icp_gold": {
-      "included": true,
-      "via": "Salesforce MCP",
-      "object": "Opportunity",
-      "filter": "StageName = 'Closed Won'"
-    },
-    "first_party_signals": {
-      "included": true,
-      "notes": "PLG + marketing + 3P intent joined by account domain."
-    }
-  },
+  "data_sources": {},
   "sections": {
     "acv": {
       "label": "ACV (size + fit)",
-      "default_pct": 60
+      "default_pct": 60.0
     },
     "intent": {
       "label": "Intent (buying window)",
-      "default_pct": 40
+      "default_pct": 40.0
     }
   },
   "categories": {
     "icp_persona_count": {
-      "label": "Icp Persona Count",
+      "label": "Persona headcount",
       "section": "acv",
-      "default_pct": 39.0
-    },
-    "icp_persona_growth": {
-      "label": "Icp Persona Growth",
-      "section": "acv",
-      "default_pct": 16.25
-    },
-    "icp_persona_concentration": {
-      "label": "Icp Persona Concentration",
-      "section": "acv",
-      "default_pct": 9.75
+      "default_pct": 16.3636
     },
     "relevant_tech_team_count": {
-      "label": "Relevant Tech Team Count",
+      "label": "Tech teams",
       "section": "acv",
-      "default_pct": 24.5
-    },
-    "relevant_tech_team_concentration": {
-      "label": "Relevant Tech Team Concentration",
-      "section": "acv",
-      "default_pct": 10.5
+      "default_pct": 10.9091
     },
     "intent_project_tech_count": {
-      "label": "Intent Project Tech Count",
+      "label": "Project \u00d7 tech",
       "section": "intent",
-      "default_pct": 45.0
+      "default_pct": 37.5
     },
-    "intent_project_persona_count": {
-      "label": "Intent Project Persona Count",
-      "section": "intent",
-      "default_pct": 30.0
+    "icp_persona_concentration": {
+      "label": "Persona concentration",
+      "section": "acv",
+      "default_pct": 21.8182,
+      "clone_from": "icp_persona_count"
+    },
+    "relevant_tech_job_concentration": {
+      "label": "Tech hiring concentration",
+      "section": "acv",
+      "default_pct": 14.5455,
+      "clone_from": "relevant_tech_team_count"
+    },
+    "icp_persona_growth": {
+      "label": "Persona growth (YoY)",
+      "section": "acv",
+      "default_pct": 36.3636,
+      "clone_from": "icp_persona_count"
     },
     "product_usage": {
       "label": "Product / PLG usage",
       "section": "intent",
-      "default_pct": 10.0
+      "default_pct": 25.0
     },
     "marketing_engagement": {
       "label": "Marketing engagement",
       "section": "intent",
-      "default_pct": 10.0
+      "default_pct": 25.0
     },
     "third_party_intent": {
       "label": "Third-party intent",
       "section": "intent",
-      "default_pct": 5.0
+      "default_pct": 12.5
     }
   },
   "signals": {
@@ -154,7 +134,8 @@
         "why": "Concentration filters out big orgs with a Sales per division.",
         "kind": "sumble_derived",
         "derivation": {
-          "formula": "100 * sales_people / employee_count_int",
+          "formula": "wilson_lb_pct(sales_people, round(sales_people / sales_people_conc))",
+          "note": "people_concentration is the endpoint's native same-scope share (people in function / people in org, both hierarchy rollups). It returns a ratio only, so the denominator is recovered by inversion \u2014 once per org from the persona with the largest headcount \u2014 and the reported value is the Wilson 95% lower bound so a 1-of-1 org cannot read 100%.",
           "inputs": [
             {
               "name": "sales_people",
@@ -169,10 +150,16 @@
               "read": "people_count"
             },
             {
-              "name": "employee_count_int",
+              "name": "sales_people_conc",
               "endpoint": "POST https://api.sumble.com/v6/organizations",
-              "select_attribute": "employee_count",
-              "read": "exact org headcount (employee_count is an integer; legacy band strings map to a midpoint)"
+              "select_entity": {
+                "type": "job_function",
+                "term": "Sales",
+                "metrics": [
+                  "people_concentration"
+                ]
+              },
+              "read": "people_concentration"
             }
           ]
         }
@@ -203,6 +190,7 @@
           "transform_note": "endpoint returns a percent (e.g. 50.0); data.csv stores it as a ratio (\u00d7 0.01)."
         }
       },
+      "fmt": "pct",
       "sumble_link": {
         "path": "/trends/job_functions_people",
         "filters": {
@@ -212,115 +200,12 @@
         }
       }
     },
-    "icp_persona_count_marketing": {
-      "label": "Marketing headcount",
-      "column": "marketing_people",
-      "category": "icp_persona_count",
-      "transform": "log",
-      "default_within": 33.33,
-      "p99": 1.0,
-      "api_supported": true,
-      "source": {
-        "why": "Marketing is a target persona \u2014 more Marketings = bigger ACV.",
-        "kind": "sumble_api",
-        "api": {
-          "endpoint": "POST https://api.sumble.com/v6/organizations",
-          "select_entity": {
-            "type": "job_function",
-            "term": "Marketing",
-            "metrics": [
-              "people_count"
-            ]
-          },
-          "read": "people_count",
-          "extract": "organizations[].entities[type='job_function',term='Marketing'].people_count"
-        }
-      },
-      "sumble_link": {
-        "path": "/people",
-        "filters": {
-          "job_function": [
-            "Marketing"
-          ]
-        }
-      }
-    },
-    "icp_persona_concentration_marketing": {
-      "label": "Marketing % of company",
-      "column": "marketing_pct",
-      "category": "icp_persona_concentration",
-      "transform": "linear",
-      "default_within": 33.33,
-      "p99": 1.0,
-      "api_supported": true,
-      "source": {
-        "why": "Concentration filters out big orgs with a Marketing per division.",
-        "kind": "sumble_derived",
-        "derivation": {
-          "formula": "100 * marketing_people / employee_count_int",
-          "inputs": [
-            {
-              "name": "marketing_people",
-              "endpoint": "POST https://api.sumble.com/v6/organizations",
-              "select_entity": {
-                "type": "job_function",
-                "term": "Marketing",
-                "metrics": [
-                  "people_count"
-                ]
-              },
-              "read": "people_count"
-            },
-            {
-              "name": "employee_count_int",
-              "endpoint": "POST https://api.sumble.com/v6/organizations",
-              "select_attribute": "employee_count",
-              "read": "exact org headcount (employee_count is an integer; legacy band strings map to a midpoint)"
-            }
-          ]
-        }
-      }
-    },
-    "icp_persona_growth_marketing": {
-      "label": "Marketing YoY growth",
-      "column": "marketing_growth_yoy",
-      "category": "icp_persona_growth",
-      "transform": "linear",
-      "default_within": 33.33,
-      "p99": 1.0,
-      "api_supported": true,
-      "source": {
-        "why": "Persona growth is a buying-window proxy \u2014 orgs growing Marketing are scaling that function.",
-        "kind": "sumble_api",
-        "api": {
-          "endpoint": "POST https://api.sumble.com/v6/organizations",
-          "select_entity": {
-            "type": "job_function",
-            "term": "Marketing",
-            "metrics": [
-              "people_count_growth_1y"
-            ]
-          },
-          "read": "people_count_growth_1y",
-          "extract": "organizations[].entities[type='job_function',term='Marketing'].people_count_growth_1y",
-          "transform_note": "endpoint returns a percent (e.g. 50.0); data.csv stores it as a ratio (\u00d7 0.01)."
-        }
-      },
-      "sumble_link": {
-        "path": "/trends/job_functions_people",
-        "filters": {
-          "job_function": [
-            "Marketing"
-          ]
-        }
-      }
-    },
     "icp_persona_count_revops": {
       "label": "RevOps headcount",
       "column": "revops_people",
       "category": "icp_persona_count",
       "transform": "log",
-      "default_within": 32.66,
+      "default_within": 33.33,
       "p99": 1.0,
       "api_supported": true,
       "source": {
@@ -353,14 +238,15 @@
       "column": "revops_pct",
       "category": "icp_persona_concentration",
       "transform": "linear",
-      "default_within": 32.66,
+      "default_within": 33.33,
       "p99": 1.0,
       "api_supported": true,
       "source": {
         "why": "Concentration filters out big orgs with a RevOps per division.",
         "kind": "sumble_derived",
         "derivation": {
-          "formula": "100 * revops_people / employee_count_int",
+          "formula": "wilson_lb_pct(revops_people, round(revops_people / revops_people_conc))",
+          "note": "people_concentration is the endpoint's native same-scope share (people in function / people in org, both hierarchy rollups). It returns a ratio only, so the denominator is recovered by inversion \u2014 once per org from the persona with the largest headcount \u2014 and the reported value is the Wilson 95% lower bound so a 1-of-1 org cannot read 100%.",
           "inputs": [
             {
               "name": "revops_people",
@@ -375,10 +261,16 @@
               "read": "people_count"
             },
             {
-              "name": "employee_count_int",
+              "name": "revops_people_conc",
               "endpoint": "POST https://api.sumble.com/v6/organizations",
-              "select_attribute": "employee_count",
-              "read": "exact org headcount (employee_count is an integer; legacy band strings map to a midpoint)"
+              "select_entity": {
+                "type": "job_function",
+                "term": "Revenue Operations",
+                "metrics": [
+                  "people_concentration"
+                ]
+              },
+              "read": "people_concentration"
             }
           ]
         }
@@ -389,7 +281,7 @@
       "column": "revops_growth_yoy",
       "category": "icp_persona_growth",
       "transform": "linear",
-      "default_within": 32.66,
+      "default_within": 33.33,
       "p99": 1.0,
       "api_supported": true,
       "source": {
@@ -409,11 +301,123 @@
           "transform_note": "endpoint returns a percent (e.g. 50.0); data.csv stores it as a ratio (\u00d7 0.01)."
         }
       },
+      "fmt": "pct",
       "sumble_link": {
         "path": "/trends/job_functions_people",
         "filters": {
           "job_function": [
             "Revenue Operations"
+          ]
+        }
+      }
+    },
+    "icp_persona_count_marketing": {
+      "label": "Marketing headcount",
+      "column": "marketing_people",
+      "category": "icp_persona_count",
+      "transform": "log",
+      "default_within": 32.66,
+      "p99": 1.0,
+      "api_supported": true,
+      "source": {
+        "why": "Marketing is a target persona \u2014 more Marketings = bigger ACV.",
+        "kind": "sumble_api",
+        "api": {
+          "endpoint": "POST https://api.sumble.com/v6/organizations",
+          "select_entity": {
+            "type": "job_function",
+            "term": "Marketing",
+            "metrics": [
+              "people_count"
+            ]
+          },
+          "read": "people_count",
+          "extract": "organizations[].entities[type='job_function',term='Marketing'].people_count"
+        }
+      },
+      "sumble_link": {
+        "path": "/people",
+        "filters": {
+          "job_function": [
+            "Marketing"
+          ]
+        }
+      }
+    },
+    "icp_persona_concentration_marketing": {
+      "label": "Marketing % of company",
+      "column": "marketing_pct",
+      "category": "icp_persona_concentration",
+      "transform": "linear",
+      "default_within": 32.66,
+      "p99": 1.0,
+      "api_supported": true,
+      "source": {
+        "why": "Concentration filters out big orgs with a Marketing per division.",
+        "kind": "sumble_derived",
+        "derivation": {
+          "formula": "wilson_lb_pct(marketing_people, round(marketing_people / marketing_people_conc))",
+          "note": "people_concentration is the endpoint's native same-scope share (people in function / people in org, both hierarchy rollups). It returns a ratio only, so the denominator is recovered by inversion \u2014 once per org from the persona with the largest headcount \u2014 and the reported value is the Wilson 95% lower bound so a 1-of-1 org cannot read 100%.",
+          "inputs": [
+            {
+              "name": "marketing_people",
+              "endpoint": "POST https://api.sumble.com/v6/organizations",
+              "select_entity": {
+                "type": "job_function",
+                "term": "Marketing",
+                "metrics": [
+                  "people_count"
+                ]
+              },
+              "read": "people_count"
+            },
+            {
+              "name": "marketing_people_conc",
+              "endpoint": "POST https://api.sumble.com/v6/organizations",
+              "select_entity": {
+                "type": "job_function",
+                "term": "Marketing",
+                "metrics": [
+                  "people_concentration"
+                ]
+              },
+              "read": "people_concentration"
+            }
+          ]
+        }
+      }
+    },
+    "icp_persona_growth_marketing": {
+      "label": "Marketing YoY growth",
+      "column": "marketing_growth_yoy",
+      "category": "icp_persona_growth",
+      "transform": "linear",
+      "default_within": 32.66,
+      "p99": 1.0,
+      "api_supported": true,
+      "source": {
+        "why": "Persona growth is a buying-window proxy \u2014 orgs growing Marketing are scaling that function.",
+        "kind": "sumble_api",
+        "api": {
+          "endpoint": "POST https://api.sumble.com/v6/organizations",
+          "select_entity": {
+            "type": "job_function",
+            "term": "Marketing",
+            "metrics": [
+              "people_count_growth_1y"
+            ]
+          },
+          "read": "people_count_growth_1y",
+          "extract": "organizations[].entities[type='job_function',term='Marketing'].people_count_growth_1y",
+          "transform_note": "endpoint returns a percent (e.g. 50.0); data.csv stores it as a ratio (\u00d7 0.01)."
+        }
+      },
+      "fmt": "pct",
+      "sumble_link": {
+        "path": "/trends/job_functions_people",
+        "filters": {
+          "job_function": [
+            "Marketing"
           ]
         }
       }
@@ -427,19 +431,19 @@
       "p99": 1.0,
       "api_supported": true,
       "source": {
-        "why": "Teams using Clay prove active, in-production adoption.",
+        "why": "Teams using the Clay tool prove active, in-production adoption.",
         "kind": "sumble_api",
         "api": {
           "endpoint": "POST https://api.sumble.com/v6/organizations",
           "select_entity": {
-            "type": "technology",
-            "term": "clay",
+            "type": "advanced_query",
+            "term": "technology EQ 'clay'",
             "metrics": [
               "team_count"
             ]
           },
           "read": "team_count",
-          "extract": "organizations[].entities[type='technology',term='clay'].team_count"
+          "extract": "organizations[].entities[type='advanced_query',term=\"technology EQ 'clay'\"].team_count"
         }
       },
       "sumble_link": {
@@ -451,38 +455,53 @@
         }
       }
     },
-    "relevant_tech_team_concentration_clay": {
-      "label": "Clay team share",
-      "column": "clay_team_pct",
-      "category": "relevant_tech_team_concentration",
+    "relevant_tech_job_concentration_clay": {
+      "label": "Clay share of hiring",
+      "column": "clay_job_pct",
+      "category": "relevant_tech_job_concentration",
       "transform": "linear",
       "default_within": 32.04,
       "p99": 1.0,
       "api_supported": true,
       "source": {
-        "why": "% of teams using Clay signals broad vs one-team adoption.",
+        "why": "% of hiring mentioning Clay signals broad vs one-team adoption.",
         "kind": "sumble_derived",
         "derivation": {
-          "formula": "100 * clay_teams / teams_count",
+          "formula": "wilson_lb_pct(clay_jobs, round(clay_jobs / clay_jobs_conc))",
+          "note": "job_post_concentration is the endpoint's native same-scope share (matching job posts / all job posts, both hierarchy rollups). It returns a ratio only, so the denominator is recovered by inversion \u2014 once per org from the tech with the most job posts \u2014 and the reported value is the Wilson 95% lower bound so a 1-of-1 org cannot read 100%.",
           "inputs": [
             {
-              "name": "clay_teams",
+              "name": "clay_jobs",
               "endpoint": "POST https://api.sumble.com/v6/organizations",
               "select_entity": {
-                "type": "technology",
-                "term": "clay",
+                "type": "advanced_query",
+                "term": "technology EQ 'clay'",
                 "metrics": [
-                  "team_count"
+                  "job_post_count"
                 ]
               },
-              "read": "team_count"
+              "read": "job_post_count"
             },
             {
-              "name": "teams_count",
+              "name": "clay_jobs_conc",
               "endpoint": "POST https://api.sumble.com/v6/organizations",
-              "select_attribute": "teams_count",
-              "read": "org-total team count (concentration denominator)"
+              "select_entity": {
+                "type": "advanced_query",
+                "term": "technology EQ 'clay'",
+                "metrics": [
+                  "job_post_concentration"
+                ]
+              },
+              "read": "job_post_concentration"
             }
+          ]
+        }
+      },
+      "sumble_link": {
+        "path": "/jobs",
+        "filters": {
+          "technology": [
+            "clay"
           ]
         }
       }
@@ -496,19 +515,19 @@
       "p99": 1.0,
       "api_supported": true,
       "source": {
-        "why": "Teams using Common Room prove active, in-production adoption.",
+        "why": "Teams using the Common Room tool prove active, in-production adoption.",
         "kind": "sumble_api",
         "api": {
           "endpoint": "POST https://api.sumble.com/v6/organizations",
           "select_entity": {
-            "type": "technology",
-            "term": "common-room",
+            "type": "advanced_query",
+            "term": "technology EQ 'common-room'",
             "metrics": [
               "team_count"
             ]
           },
           "read": "team_count",
-          "extract": "organizations[].entities[type='technology',term='common-room'].team_count"
+          "extract": "organizations[].entities[type='advanced_query',term=\"technology EQ 'common-room'\"].team_count"
         }
       },
       "sumble_link": {
@@ -520,38 +539,53 @@
         }
       }
     },
-    "relevant_tech_team_concentration_common-room": {
-      "label": "Common Room team share",
-      "column": "common-room_team_pct",
-      "category": "relevant_tech_team_concentration",
+    "relevant_tech_job_concentration_common-room": {
+      "label": "Common Room share of hiring",
+      "column": "common-room_job_pct",
+      "category": "relevant_tech_job_concentration",
       "transform": "linear",
       "default_within": 31.4,
       "p99": 1.0,
       "api_supported": true,
       "source": {
-        "why": "% of teams using Common Room signals broad vs one-team adoption.",
+        "why": "% of hiring mentioning Common Room signals broad vs one-team adoption.",
         "kind": "sumble_derived",
         "derivation": {
-          "formula": "100 * common-room_teams / teams_count",
+          "formula": "wilson_lb_pct(common-room_jobs, round(common-room_jobs / common-room_jobs_conc))",
+          "note": "job_post_concentration is the endpoint's native same-scope share (matching job posts / all job posts, both hierarchy rollups). It returns a ratio only, so the denominator is recovered by inversion \u2014 once per org from the tech with the most job posts \u2014 and the reported value is the Wilson 95% lower bound so a 1-of-1 org cannot read 100%.",
           "inputs": [
             {
-              "name": "common-room_teams",
+              "name": "common-room_jobs",
               "endpoint": "POST https://api.sumble.com/v6/organizations",
               "select_entity": {
-                "type": "technology",
-                "term": "common-room",
+                "type": "advanced_query",
+                "term": "technology EQ 'common-room'",
                 "metrics": [
-                  "team_count"
+                  "job_post_count"
                 ]
               },
-              "read": "team_count"
+              "read": "job_post_count"
             },
             {
-              "name": "teams_count",
+              "name": "common-room_jobs_conc",
               "endpoint": "POST https://api.sumble.com/v6/organizations",
-              "select_attribute": "teams_count",
-              "read": "org-total team count (concentration denominator)"
+              "select_entity": {
+                "type": "advanced_query",
+                "term": "technology EQ 'common-room'",
+                "metrics": [
+                  "job_post_concentration"
+                ]
+              },
+              "read": "job_post_concentration"
             }
+          ]
+        }
+      },
+      "sumble_link": {
+        "path": "/jobs",
+        "filters": {
+          "technology": [
+            "common-room"
           ]
         }
       }
@@ -565,19 +599,19 @@
       "p99": 1.0,
       "api_supported": true,
       "source": {
-        "why": "Teams using HG Insights prove active, in-production adoption.",
+        "why": "Teams using the HG Insights tool prove active, in-production adoption.",
         "kind": "sumble_api",
         "api": {
           "endpoint": "POST https://api.sumble.com/v6/organizations",
           "select_entity": {
-            "type": "technology",
-            "term": "hg-insights",
+            "type": "advanced_query",
+            "term": "technology EQ 'hg-insights'",
             "metrics": [
               "team_count"
             ]
           },
           "read": "team_count",
-          "extract": "organizations[].entities[type='technology',term='hg-insights'].team_count"
+          "extract": "organizations[].entities[type='advanced_query',term=\"technology EQ 'hg-insights'\"].team_count"
         }
       },
       "sumble_link": {
@@ -589,38 +623,53 @@
         }
       }
     },
-    "relevant_tech_team_concentration_hg-insights": {
-      "label": "HG Insights team share",
-      "column": "hg-insights_team_pct",
-      "category": "relevant_tech_team_concentration",
+    "relevant_tech_job_concentration_hg-insights": {
+      "label": "HG Insights share of hiring",
+      "column": "hg-insights_job_pct",
+      "category": "relevant_tech_job_concentration",
       "transform": "linear",
       "default_within": 18.46,
       "p99": 1.0,
       "api_supported": true,
       "source": {
-        "why": "% of teams using HG Insights signals broad vs one-team adoption.",
+        "why": "% of hiring mentioning HG Insights signals broad vs one-team adoption.",
         "kind": "sumble_derived",
         "derivation": {
-          "formula": "100 * hg-insights_teams / teams_count",
+          "formula": "wilson_lb_pct(hg-insights_jobs, round(hg-insights_jobs / hg-insights_jobs_conc))",
+          "note": "job_post_concentration is the endpoint's native same-scope share (matching job posts / all job posts, both hierarchy rollups). It returns a ratio only, so the denominator is recovered by inversion \u2014 once per org from the tech with the most job posts \u2014 and the reported value is the Wilson 95% lower bound so a 1-of-1 org cannot read 100%.",
           "inputs": [
             {
-              "name": "hg-insights_teams",
+              "name": "hg-insights_jobs",
               "endpoint": "POST https://api.sumble.com/v6/organizations",
               "select_entity": {
-                "type": "technology",
-                "term": "hg-insights",
+                "type": "advanced_query",
+                "term": "technology EQ 'hg-insights'",
                 "metrics": [
-                  "team_count"
+                  "job_post_count"
                 ]
               },
-              "read": "team_count"
+              "read": "job_post_count"
             },
             {
-              "name": "teams_count",
+              "name": "hg-insights_jobs_conc",
               "endpoint": "POST https://api.sumble.com/v6/organizations",
-              "select_attribute": "teams_count",
-              "read": "org-total team count (concentration denominator)"
+              "select_entity": {
+                "type": "advanced_query",
+                "term": "technology EQ 'hg-insights'",
+                "metrics": [
+                  "job_post_concentration"
+                ]
+              },
+              "read": "job_post_concentration"
             }
+          ]
+        }
+      },
+      "sumble_link": {
+        "path": "/jobs",
+        "filters": {
+          "technology": [
+            "hg-insights"
           ]
         }
       }
@@ -634,19 +683,19 @@
       "p99": 1.0,
       "api_supported": true,
       "source": {
-        "why": "Teams using ZoomInfo prove active, in-production adoption.",
+        "why": "Teams using the ZoomInfo tool prove active, in-production adoption.",
         "kind": "sumble_api",
         "api": {
           "endpoint": "POST https://api.sumble.com/v6/organizations",
           "select_entity": {
-            "type": "technology",
-            "term": "zoominfo",
+            "type": "advanced_query",
+            "term": "technology EQ 'zoominfo'",
             "metrics": [
               "team_count"
             ]
           },
           "read": "team_count",
-          "extract": "organizations[].entities[type='technology',term='zoominfo'].team_count"
+          "extract": "organizations[].entities[type='advanced_query',term=\"technology EQ 'zoominfo'\"].team_count"
         }
       },
       "sumble_link": {
@@ -658,44 +707,59 @@
         }
       }
     },
-    "relevant_tech_team_concentration_zoominfo": {
-      "label": "ZoomInfo team share",
-      "column": "zoominfo_team_pct",
-      "category": "relevant_tech_team_concentration",
+    "relevant_tech_job_concentration_zoominfo": {
+      "label": "ZoomInfo share of hiring",
+      "column": "zoominfo_job_pct",
+      "category": "relevant_tech_job_concentration",
       "transform": "linear",
       "default_within": 18.09,
       "p99": 1.0,
       "api_supported": true,
       "source": {
-        "why": "% of teams using ZoomInfo signals broad vs one-team adoption.",
+        "why": "% of hiring mentioning ZoomInfo signals broad vs one-team adoption.",
         "kind": "sumble_derived",
         "derivation": {
-          "formula": "100 * zoominfo_teams / teams_count",
+          "formula": "wilson_lb_pct(zoominfo_jobs, round(zoominfo_jobs / zoominfo_jobs_conc))",
+          "note": "job_post_concentration is the endpoint's native same-scope share (matching job posts / all job posts, both hierarchy rollups). It returns a ratio only, so the denominator is recovered by inversion \u2014 once per org from the tech with the most job posts \u2014 and the reported value is the Wilson 95% lower bound so a 1-of-1 org cannot read 100%.",
           "inputs": [
             {
-              "name": "zoominfo_teams",
+              "name": "zoominfo_jobs",
               "endpoint": "POST https://api.sumble.com/v6/organizations",
               "select_entity": {
-                "type": "technology",
-                "term": "zoominfo",
+                "type": "advanced_query",
+                "term": "technology EQ 'zoominfo'",
                 "metrics": [
-                  "team_count"
+                  "job_post_count"
                 ]
               },
-              "read": "team_count"
+              "read": "job_post_count"
             },
             {
-              "name": "teams_count",
+              "name": "zoominfo_jobs_conc",
               "endpoint": "POST https://api.sumble.com/v6/organizations",
-              "select_attribute": "teams_count",
-              "read": "org-total team count (concentration denominator)"
+              "select_entity": {
+                "type": "advanced_query",
+                "term": "technology EQ 'zoominfo'",
+                "metrics": [
+                  "job_post_concentration"
+                ]
+              },
+              "read": "job_post_concentration"
             }
+          ]
+        }
+      },
+      "sumble_link": {
+        "path": "/jobs",
+        "filters": {
+          "technology": [
+            "zoominfo"
           ]
         }
       }
     },
     "intent_project_tech_count_go-to-market-modernization": {
-      "label": "GTM Modernization \u00d7 ICP tech jobs (3mo)",
+      "label": "GTM Modernization \u00d7 tech (3mo)",
       "column": "go-to-market-modernization_x_relevant_tech_jobposts",
       "category": "intent_project_tech_count",
       "transform": "log",
@@ -713,7 +777,7 @@
             "metrics": [
               "job_post_count"
             ],
-            "since": "2026-03-01"
+            "since": "2026-04-23"
           },
           "read": "job_post_count",
           "extract": "organizations[].entities[type='advanced_query',term=\"project EQ 'go-to-market-modernization' AND technology IN ('clay', 'common-room', 'hg-insights', 'zoominfo')\"].job_post_count",
@@ -737,98 +801,13 @@
           ]
         }
       }
-    },
-    "intent_project_persona_count_go-to-market-modernization": {
-      "label": "GTM Modernization \u00d7 ICP persona jobs (3mo)",
-      "column": "go-to-market-modernization_x_relevant_persona_jobposts",
-      "category": "intent_project_persona_count",
-      "transform": "log",
-      "default_within": 100.0,
-      "p99": 1.0,
-      "api_supported": true,
-      "source": {
-        "why": "Recent GTM Modernization jobs for an ICP persona show who is staffing the project \u2014 buying-window + fit.",
-        "kind": "sumble_api",
-        "api": {
-          "endpoint": "POST https://api.sumble.com/v6/organizations",
-          "select_entity": {
-            "type": "advanced_query",
-            "term": "project EQ 'go-to-market-modernization' AND job_function IN ('Sales', 'Marketing', 'Revenue Operations')",
-            "metrics": [
-              "job_post_count"
-            ],
-            "since": "2026-03-01"
-          },
-          "read": "job_post_count",
-          "extract": "organizations[].entities[type='advanced_query',term=\"project EQ 'go-to-market-modernization' AND job_function IN ('Sales', 'Marketing', 'Revenue Operations')\"].job_post_count",
-          "since_note": "3-month window; recompute `since` to run date \u2212 3 months."
-        }
-      },
-      "sumble_link": {
-        "path": "/jobs",
-        "filters": {
-          "project": [
-            "go-to-market-modernization"
-          ],
-          "job_function": [
-            "Sales",
-            "Marketing",
-            "Revenue Operations"
-          ],
-          "hiring_period": [
-            "3mo"
-          ]
-        }
-      }
-    },
-    "plg_active_users_28d": {
-      "label": "Active users (28d)",
-      "column": "plg_active_users_28d",
-      "category": "product_usage",
-      "transform": "log",
-      "default_within": 100.0,
-      "p99": 6.5,
-      "api_supported": false,
-      "api_unsupported_reason": "First-party signal \u2014 not in Sumble's public API.",
-      "source": {
-        "kind": "first_party",
-        "why": "Existing product engagement is the strongest expansion signal.",
-        "synced_pointer": "warehouse/product_usage.active_users_28d (join by account domain)"
-      }
-    },
-    "marketing_event_attendees": {
-      "label": "Event attendees (90d)",
-      "column": "marketing_event_attendees",
-      "category": "marketing_engagement",
-      "transform": "log",
-      "default_within": 100.0,
-      "p99": 3.2,
-      "api_supported": false,
-      "api_unsupported_reason": "First-party signal \u2014 not in Sumble's public API.",
-      "source": {
-        "kind": "first_party",
-        "why": "Recent event engagement signals active interest.",
-        "synced_pointer": "hubspot/marketing.event_attendees_90d (join by account domain)"
-      }
-    },
-    "intent_topic_surge_score": {
-      "label": "3P intent surge",
-      "column": "intent_topic_surge_score",
-      "category": "third_party_intent",
-      "transform": "linear",
-      "default_within": 100.0,
-      "p99": 60.0,
-      "api_supported": false,
-      "api_unsupported_reason": "First-party signal \u2014 not in Sumble's public API.",
-      "source": {
-        "kind": "first_party",
-        "why": "Off-property research before the account raises a hand.",
-        "synced_pointer": "6sense/intent.topic_surge_score (join by account domain)"
-      }
     }
   },
   "multipliers": [],
   "tag_multipliers": [],
   "tag_multipliers_defaults": [],
-  "_tag_calibration_audit": {}
+  "_tag_calibration_audit": {
+    "attrs": {},
+    "industries": {}
+  }
 }

--- a/skills/sumble-account-scoring/template/score_accounts.py
+++ b/skills/sumble-account-scoring/template/score_accounts.py
@@ -204,6 +204,9 @@ def collect_select(signals_scored: dict[str, dict]) -> dict:
                 "term": ent["term"],
                 "metrics": list(ent.get("metrics") or []),
                 **({"since": ent["since"]} if "since" in ent else {}),
+                # Required by the endpoint for technology_category, rejected for
+                # every other type — so carry it through exactly as configured.
+                **({"granularity": ent["granularity"]} if ent.get("granularity") else {}),
             }
         else:
             for m in ent.get("metrics") or []:
@@ -270,7 +273,74 @@ def _days_since_attr(src: dict, attrs: dict) -> float:
     return float(max(1, (_dt.date.today() - d).days))
 
 
-def signal_raw(sig: dict, ents: dict, attrs: dict) -> float:
+# The endpoint's native concentration metrics. Both sides of each ratio are
+# hierarchy rollups, so a parent org's share can never exceed 100%.
+CONCENTRATION_METRICS = ("people_concentration", "job_post_concentration")
+
+CONFIDENCE_Z = 1.96
+
+
+def wilson_lb_pct(numerator: float, denominator: float) -> float:
+    """Concentration percentage as the Wilson 95% lower confidence bound — the
+    lowest share that could plausibly explain what we observed. Mirrors
+    `sumble_v6._share` exactly so this scorer and the app agree.
+
+    A raw ratio scores 1/1 and 900/900 identically at 100%, letting orgs we know
+    almost nothing about saturate the signal; the lower bound shrinks thin
+    evidence toward 0 and leaves well-measured orgs essentially untouched.
+    """
+    if numerator <= 0 or denominator <= 0:
+        return 0.0
+    z, n = CONFIDENCE_Z, max(denominator, numerator)
+    p = numerator / n
+    z2 = z * z
+    lb = (
+        p + z2 / (2 * n) - z * math.sqrt(p * (1 - p) / n + z2 / (4 * n * n))
+    ) / (1 + z2 / n)
+    return round(max(100.0 * lb, 0.0), 3)
+
+
+def concentration_metric(sig: dict) -> str | None:
+    """The native concentration metric a signal's derivation inverts, if any."""
+    deriv = (sig.get("source") or {}).get("derivation")
+    if not isinstance(deriv, dict):
+        return None
+    inputs = deriv.get("inputs") or []
+    if len(inputs) < 2:
+        return None
+    read = inputs[1].get("read") or ""
+    return read if read in CONCENTRATION_METRICS else None
+
+
+def recover_totals(
+    config: dict, eff: dict[str, float], ents: dict, attrs: dict
+) -> dict[str, float]:
+    """metric -> the org-wide concentration DENOMINATOR, recovered by inversion.
+
+    WORKAROUND — delete once /v6/organizations exposes hierarchy-scoped counts
+    as attributes (flagged to the API team). The concentration metrics return a
+    ratio only, but the Wilson bound needs the sample size, so we invert:
+    `denominator = count / ratio`. The ratio is rounded to 4dp, so precision
+    degrades as the share shrinks — every signal sharing a metric also shares one
+    org-wide denominator, so recover it once from the LARGEST count available
+    (the best-conditioned pair) and reuse it. Mirrors `sumble_v6.recover_total`.
+    """
+    best: dict[str, tuple[float, float]] = {}
+    for key in eff:
+        metric = concentration_metric(config["signals"][key])
+        if not metric:
+            continue
+        inputs = config["signals"][key]["source"]["derivation"]["inputs"]
+        count = _input_value(inputs[0], ents, attrs)
+        ratio = _input_value(inputs[1], ents, attrs)
+        if ratio > 0 and count > best.get(metric, (0.0, 0.0))[0]:
+            best[metric] = (count, count / ratio)
+    return {m: round(total) for m, (_, total) in best.items()}
+
+
+def signal_raw(
+    sig: dict, ents: dict, attrs: dict, totals: dict[str, float] | None = None
+) -> float:
     src = sig.get("source", {})
     if sig.get("transform") == "recency":
         return _days_since_attr(src, attrs)
@@ -283,7 +353,13 @@ def signal_raw(sig: dict, ents: dict, attrs: dict) -> float:
     deriv = src.get("derivation")
     if isinstance(deriv, dict):
         inputs = deriv.get("inputs") or []
-        # api_supported derived signals are concentrations: 100 * num / denom.
+        # Concentration: count + native ratio -> Wilson bound over the org-wide
+        # denominator recovered once per org.
+        metric = concentration_metric(sig)
+        if metric:
+            num = _input_value(inputs[0], ents, attrs)
+            return wilson_lb_pct(num, (totals or {}).get(metric, 0.0))
+        # Older configs express a concentration as a plain 100 * num / denom.
         if len(inputs) >= 2:
             num = _input_value(inputs[0], ents, attrs)
             den = _input_value(inputs[1], ents, attrs)
@@ -424,14 +500,16 @@ def sumble_link(base: str, slug: str, spec: dict | None) -> str:
         if field in ("technology", "technology_category"):
             if tech_done:
                 continue
-            groups.append({
-                "operator": "OR",
-                "fields": {
-                    k: {"include": raw_filters[k], "exclude": []}
-                    for k in ("technology", "technology_category")
-                    if k in raw_filters
-                },
-            })
+            groups.append(
+                {
+                    "operator": "OR",
+                    "fields": {
+                        k: {"include": raw_filters[k], "exclude": []}
+                        for k in ("technology", "technology_category")
+                        if k in raw_filters
+                    },
+                }
+            )
             tech_done = True
             continue
         groups.append(
@@ -475,9 +553,12 @@ def build_row(account: dict, resp_org: dict, config: dict, eff: dict[str, float]
     # spec — so the scored output is clickable, like the app's score.csv.
     row["sumble_url"] = f"{link_base}{slug}" if slug else ""
 
+    # One recovered denominator per concentration metric, shared by every signal
+    # that uses it (see recover_totals).
+    totals = recover_totals(config, eff, ents, attrs)
     for key in eff:
         sig = config["signals"][key]
-        row[sig["column"]] = signal_raw(sig, ents, attrs)
+        row[sig["column"]] = signal_raw(sig, ents, attrs, totals)
         if sig.get("sumble_link"):
             row[f"{sig['column']}_link"] = sumble_link(
                 link_base, slug, sig.get("sumble_link")


### PR DESCRIPTION
## Summary

Two changes to `sumble-account-scoring`.

### 1. Synthetic technology categories

Sumble's predefined categories are general-purpose, so a specific ICP often has none that expresses it (there is no "Offensive Security Tooling" category). A spec tech can now be `kind: "synthetic"` — an authored grouping sent as an `advanced_query` and counted as **one deduped `team_count`**, so a team using three members counts once. It can absorb whole predefined categories via `member_categories` and extend them with extra `members`, which keeps the signal in sync when Sumble later adds a technology to that category.

SKILL.md carries the guardrails: every member defensibly ICP, watch for a dominating member (volume ratio flags it, conceptual breadth is the test), reject ambiguous slugs (`hydra`, `cobalt`), 3–15 members, `syn-` prefix, and full membership confirmed by the user before any credit is spent. Also adds a **"group every tech"** doctrine — a standalone individual tech is now the last resort rather than the default, since sparse one-off techs mostly read 0 and double-count the same team across signals.

### 2. Concentration now uses the endpoint's native same-scope metrics

Previously a concentration was an entity count ÷ an org attribute. Those cover different populations — entity metrics roll up the org hierarchy, attributes are scoped to the matched record alone — so parent orgs blew past 100%. **Advance** reports 252 Design teams across its subsidiaries against a `teams_count` of 6, i.e. *"4200% of teams"*.

`{jf}_pct` now comes from `people_concentration` and `{tech}_job_pct` from `job_post_concentration`, where both sides are hierarchy rollups — the mismatch cannot arise, and the previous suppress-and-flag workaround (`concentration_scope_ok`) is deleted. That holdco now scores a sensible 6.49% instead of being zeroed out.

Reported as the **Wilson 95% lower confidence bound** rather than the raw ratio. A raw share scores 1/1 and 900/900 identically at 100%, so barely-measured orgs saturated the signal — 192 orgs at ≥99% share with a *median denominator of 1* on a 4,884-row pull — and the p99 normaliser fit to them, meaning the signal was ranking how *little* data an org had.

| observed | raw | Wilson LB |
|---|---|---|
| 1/1 | 100% | 20.7% |
| 9/9 | 100% | 70.1% |
| 266/3630 | 7.3% | 6.5% |

This replaces two hand-tuned smoothing constants with one standard `z=1.96`.

## Consequences worth knowing

- **Tech concentration is now a share of *hiring*, not of teams** — `job_post_concentration` is the only concentration metric `advanced_query` exposes. Category key `relevant_tech_team_concentration` → `relevant_tech_job_concentration`; column `{tech}_team_pct` → `{tech}_job_pct`. New columns `{tech}_jobs`, `people_total_est`, `jobs_total_est`.
- **All three tech kinds now go out as `advanced_query`** — semantically free, since the endpoint implements a `technology_category` aggregate by building exactly that query and running it through the same counter. Side effect: `granularity` disappears entirely.
- **Cost:** +2 credits per tech·org, +1 per persona·org.

## Known workaround

The concentration metrics return a **ratio, not a denominator**, and Wilson needs the sample size — so `recover_total` inverts it (`den = count / ratio`). The ratio is rounded to 4dp, so precision degrades on small shares (~25% off at a 0.02% share; unrecoverable below ~0.005%). Since every persona shares one org-wide denominator and every tech shares one, it is recovered **once per org from the largest count**, which keeps it well-conditioned. Both recovered totals are written to `data.csv` so any share is auditable.

Filed with the API team ([#p-mcp](https://sumbleworkspace.slack.com/archives/C0AK1593MK7/p1784728585193889)) to expose hierarchy-scoped counts as v6 attributes — `hp_jobs_count` / `hp_people_count` / `hp_teams_count` already exist on the `organizations` table — which removes the recovery entirely.

## Also

Regenerated `account-scoring-weights.example.json`, which surfaced two pre-existing staleness bugs: an `intent_project_persona_count` category that `build_weights` no longer produces, and a provenance note claiming tech concentration was not API-supported.

## Test plan

- Wilson values match the reference table (1/1 → 20.65, 9/9 → 70.09, 28/50 → 42.31, 266/3630 → 6.52, 500/22251 → 2.06)
- The build pipeline and the portable `score_accounts.py` produce **identical** concentrations on a simulated holding-company response
- Denominator recovery verified to pick the best-conditioned pair (exact 20,000 from a 645-post tech vs 15,000 from a 3-post one)
- `entity_plan` / `build_select` emit no `granularity` on `advanced_query`; all three tech kinds carry the 3 metrics
- All scripts compile; `validate_skill_metadata.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)