### PR TITLE
Remove deploy/build-your-own sections from example READMEs

### DIFF
--- a/examples/account-scoring/README.md
+++ b/examples/account-scoring/README.md
@@ -39,24 +39,3 @@ port with `python app.py 9001` or `PORT=9001 python app.py`.
 
 `score.csv` is regenerated from `data.csv` + the weights on startup and on Save
 (it's git-ignored here).
-
-## Deploy your own
-
-This folder is a self-contained Cloud Run app. From here:
-
-```bash
-gcloud run deploy sumble-account-scoring-demo \
-  --source . --region us-west1 --allow-unauthenticated --memory 1Gi
-```
-
-The `Dockerfile` is trivial (stdlib only); the app reads `$PORT` and binds
-`$HOST=0.0.0.0` in the container. `score.csv` is regenerated in the container at
-startup, so only `data.csv` + the weights JSON need to ship.
-
-## Build your own
-
-This is just example output. To build a score against *your* ICP and *your*
-accounts, install the [`account-scoring`](../../skills/sumble-account-scoring)
-skill and run it in your coding agent. The method is written up in the
-[articles](../../skills/sumble-account-scoring/articles): [Part 1 — the method](../../skills/sumble-account-scoring/articles/01-account-score-should-tell-a-rep-what-to-do.md)
-and [Part 2 — build it](../../skills/sumble-account-scoring/articles/02-build-an-account-score-you-can-prospect-from.md).

--- a/examples/crm-cleaning/README.md
+++ b/examples/crm-cleaning/README.md
@@ -64,14 +64,3 @@ Then **Export actions.csv** for the change list (`merge` / `delete` /
 | `static/` | The UI. |
 
 `decisions.json` and `actions.csv` are written as you review (gitignored).
-
-## Build this against your own CRM
-
-Install the skill and run it — the interview takes a few minutes:
-
-```bash
-npx skills add SumbleData/sumble-skills-public --skill sumble-crm-cleaning
-```
-
-The method is written up in
-[Clean your CRM against an org graph](../../skills/sumble-crm-cleaning/articles/01-clean-your-crm-against-the-org-graph.md).

--- a/examples/people-scoring/README.md
+++ b/examples/people-scoring/README.md
@@ -46,29 +46,6 @@ Stock Python 3.10+, stdlib only — no `pip install`.
 The method is written up in
 [the people-scoring article](../../skills/sumble-people-scoring/articles/01-people-scoring-use-cases.md).
 
-## Deploy
-
-This folder is a self-contained Cloud Run app (stdlib-only `Dockerfile`; the app
-reads `$PORT` and binds `$HOST=0.0.0.0`). `score.csv` is regenerated in the
-container at startup, so only `data.csv` + `config.json` need to ship. Deploy
-into the same GCP project that hosts the account demo (where `sumble.com` is
-verified for domain mapping):
-
-```bash
-cd sumble-skills/examples/people-scoring
-
-# 1. Deploy the service.
-gcloud run deploy sumble-people-scoring-demo \
-  --source . --region us-west1 --allow-unauthenticated --memory 1Gi
-
-# 2. Map the custom domain (one-time), then add the records gcloud prints
-#    to the sumble.com DNS zone.
-gcloud beta run domain-mappings create \
-  --service sumble-people-scoring-demo \
-  --domain people-scoring-demo.sumble.com \
-  --region us-west1
-```
-
 ## Security note
 
 The local app binds 127.0.0.1 and has no auth. `data.csv` is real

--- a/examples/territory-planning/README.md
+++ b/examples/territory-planning/README.md
@@ -44,22 +44,3 @@ bash examples/territory-planning/build.sh
 `make_demo.py` is the generator (accounts + scores + reps + ownership +
 activity); tweak `ENTERPRISE_REPS` / `COMMERCIAL_REPS`, the boundary, or the
 `*_weight` tables there to reshape the demo.
-
-## Deploy
-
-The demo ships a `Dockerfile` and reads `$PORT` / `$HOST`, and gates itself with
-HTTP Basic Auth when `BASIC_AUTH_PASS` is set — so it deploys anywhere.
-
-**fly.io** (via the internal `fly-deploy` skill), or **Google Cloud Run**:
-
-```bash
-gcloud run deploy sumble-territory-demo \
-  --source examples/territory-planning \
-  --region us-central1 --allow-unauthenticated --port 8080 \
-  --set-env-vars BASIC_AUTH_USER=demo,BASIC_AUTH_PASS=demo \
-  --project <your-gcp-project>
-```
-
-> The container filesystem is ephemeral — allocations/calibrations made on the
-> live demo reset when the instance recycles (which is fine for a demo: every
-> viewer gets a clean slate). Export `actions.csv` to keep a session's changes.


### PR DESCRIPTION
Removes the "Deploy your own" / "Build your own" (and equivalent deploy) sections from the four example READMEs, keeping each focused on running and understanding the demo.

- **account-scoring** — removed `## Deploy your own` and `## Build your own`
- **territory-planning** — removed `## Deploy` (Cloud Run / fly.io)
- **crm-cleaning** — removed `## Build this against your own CRM`
- **people-scoring** — removed `## Deploy` (Cloud Run + domain mapping)

Kept `## Rebuild from source` (territory-planning, demo provenance) and `## Security note` (people-scoring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)