### PR TITLE
sumble-account-research: freshness gate + dual person links with real confidence scores

### DIFF
--- a/skills/sumble-account-research/SKILL.md
+++ b/skills/sumble-account-research/SKILL.md
@@ -208,11 +208,33 @@ recent moves/promotions.
 signal + cleanest entry; expansion → team adjacent to the existing footprint). Prefer a
 **real, navigable Sumble team** (grab its `slug` from the contacts' `matched_features`, so
 the deliverable can link its roster) over a bare description.
-**Why now** — the 1–2 signals. **Who to get to** — name the **economic buyer**
-(leader over the team), **champion/user** (hands-on lead or the signal job's hiring
-manager), and **multithread** contacts; use `FindMatchAndEnrichPeople` +
-`related_people` to map buyers ↔ implementers. Keep to 2–3. In the deliverable these render
-as a labelled buying group — team + path to the buyer + role-tagged contacts, not a bare list.
+**Why now** — the 1–2 signals, plus the tech/hiring evidence (what they run and how
+heavily) the deliverable will cite.
+
+**The buying group (shared output — every deliverable renders this; Step 5d only changes
+the medium).** Name 2–3 people — the **economic buyer** (leader over the team), the
+**champion/user** (hands-on lead or the signal job's hiring manager), and any
+**multithread** contact — and build each the same way, once, here, so every deliverable
+inherits the same well-formed group:
+- **Both links per person.** Every name carries a **LinkedIn** link *and* a **Sumble
+  people-page** link (the `sumble_url` the API returns) — the Sumble page is where the
+  confidence-scored roll-up lives.
+- **Scored reporting line.** Pull it with `FindMatchAndEnrichPeople` in **match mode**,
+  batching the contacts, with `related_people: { direction: ["direct_reports"],
+  attributes: ["name","job_title","job_level","linkedin_url","confidence"] }` — the inner
+  `attributes` is what returns names/links/scores. Each report's `confidence.score` (0–1,
+  at the **top level**) → the web-app **1–10** via `ceil(score*100)/10`; rank by it, show
+  the top ~5. `direct_reports` only — managers are near-empty for senior people.
+- **Path in.** One line: champion → economic buyer.
+- **Every listed person is accounted for.** Each contact gets either their scored line or
+  an explicit note saying why not (no reports mapped / shown under an anchor above / line
+  already shown elsewhere) — never a bare name with a silent gap. Noisy/off-target lines
+  (common for CXOs) become a note, not padding.
+
+This buying group is the canonical output. **Step 5d renders it in whatever medium the
+deliverable is** — a labelled block with role chips + a fan-out in the interactive brief, a
+slide, the attendee org-map in a call-prep doc, or the recipient list + multithread plan of
+an outreach sequence. The medium changes; the group, its scores, and its links don't.
 
 **Freshness gate (required before any name reaches the deliverable).** Sumble
 people records go stale — departed execs still listed as current, and current
@@ -245,8 +267,10 @@ the matching sales play / reference customer.
 hedges and the em-dash-padded filler. It should read like a sharp rep wrote it, not a
 generated draft.
 
-- **Outreach sequences:** a multi-touch sequence for each priority person (≤3) —
-  email plus optional LinkedIn / call steps, each touch a distinct angle (signal-led,
+- **Outreach sequences:** a multi-touch sequence for each priority person (≤3) — **these
+  are the Step 5c buying group** (lead with the economic buyer + champion; use their
+  reporting line to pick multithread targets). Email plus optional LinkedIn / call steps,
+  each touch a distinct angle (signal-led,
   reference-led, value-led). First touch leans on internal context; later touches on
   specific external signals. Human and specific; no "I noticed you're hiring" filler.
   **Match the rep's voice:** if a CRM connector is available (e.g. Salesforce —
@@ -256,22 +280,25 @@ generated draft.
   rules still apply.
 - **Account plan:** a written plan in the **format from Step 1**, pitched to
   the stated audience (your own strategy prep, SDR→AE handoff, AE→manager, or QBR). Cover: account snapshot +
-  ICP fit, why now (signals), target team(s) + entry point, the buying group (buyer /
-  champion / multithread) with the org map, current state (pipeline / existing
-  business), and recommended next steps. **If they gave an example, match its structure,
+  ICP fit, why now (signals), target team(s) + entry point, the **Step 5c buying group**
+  (buyer / champion / multithread) rendered with its confidence-scored org map and both
+  links per person, current state (pipeline / existing business), and recommended next
+  steps. **If they gave an example, match its structure,
   length, and tone.** If they didn't, structure it cleanly in **the seller's own company
   branding (`references/branding.md`)** — their colors, type, logo.
 - **Deck:** a slide outline first, then full slide content, in the **format/medium from
   Step 1**. Typical arc: who they are + why now → what we see in their
   stack / teams / hiring → the problem we solve for the target team → proof (reference
-  customer) → a clear next step. Only slides that earn their place. **If they gave an
+  customer) → the **Step 5c buying group** as a "who to reach" slide (team + path to the
+  buyer + role-tagged contacts) → a clear next step. Only slides that earn their place. **If they gave an
   example, match its template, layout, and tone.** If they didn't, design it in **the
   seller's own company branding (`references/branding.md`)** — their palette, type, and
   logo on the title / closing slide (it's presented to the prospect under the seller's
   name, not Sumble's).
 - **Call prep brief:** a one-page brief they can scan five minutes before the
   meeting. Cover: **the meeting** (type, goal, one-line account state); **attendees,
-  most senior first** — for each: role, tenure, background, reporting line, recent
+  most senior first** — for each: role, tenure, background, their **Step 5c scored
+  reporting line** (who rolls up to them, with the 1–10 confidence + both links), recent
   moves/promotions, and *your history with them* (last touchpoint, what was said,
   open threads); **why now** — the 1–2 freshest signals with dates; **talking
   points + discovery questions** tied to their stack/teams/hiring; **landmines**

--- a/skills/sumble-account-research/SKILL.md
+++ b/skills/sumble-account-research/SKILL.md
@@ -211,6 +211,28 @@ signal + cleanest entry; expansion → team adjacent to the existing footprint).
 manager), and **multithread** contacts; use `FindMatchAndEnrichPeople` +
 `related_people` to map buyers ↔ implementers. Keep to 2–3.
 
+**Freshness gate (required before any name reaches the deliverable).** Sumble
+people records go stale — departed execs still listed as current, and current
+execs mislabeled (wrong title, missing reports). A customer-facing brief with a
+"contact" who left is a trust-killer. So verify **every named person** — especially
+economic buyer / champion and anyone in a reporting fan-out — is *currently at the
+company* before including them (quick web / LinkedIn check on the person's current
+role; the person's own current LinkedIn is the tiebreaker over the Sumble title).
+Two outcomes, handled differently:
+- **Departed** (no longer at the company) → **drop them.** Don't list them, don't
+  anchor a fan-out on them, don't reveal contact info. If they were the obvious
+  buyer, find their replacement instead.
+- **Active but stale Sumble record** (right person, wrong/old title, or 0 reports
+  like a mislabeled "Board Member") → **keep them** — never drop an active buyer over
+  a messy record — but **use the verified current title**, not the Sumble one, and
+  add a one-line note that the Sumble record is stale. If the Sumble people page is
+  actively misleading (wrong title), you may keep the link (it's still the right
+  person) but the note must explain it; if the record is so wrong the link would
+  confuse, show LinkedIn only and mark Sumble n/a.
+
+Apply the same test to fan-out reports: a departed report is dropped from the line;
+the score/roll-up you show should reflect people actually still there.
+
 **5d. Produce the chosen deliverable** (from Step 1) — all built from the same
 research, grounded in internal context first, then a specific external signal, then
 the matching sales play / reference customer.

--- a/skills/sumble-account-research/SKILL.md
+++ b/skills/sumble-account-research/SKILL.md
@@ -205,11 +205,14 @@ and who else sits near the deal; check `SearchSignals` with their `person_ids` f
 recent moves/promotions.
 
 **5c. Recommend.** **Where to focus** — the target team (first land → strongest
-signal + cleanest entry; expansion → team adjacent to the existing footprint).
+signal + cleanest entry; expansion → team adjacent to the existing footprint). Prefer a
+**real, navigable Sumble team** (grab its `slug` from the contacts' `matched_features`, so
+the deliverable can link its roster) over a bare description.
 **Why now** — the 1–2 signals. **Who to get to** — name the **economic buyer**
 (leader over the team), **champion/user** (hands-on lead or the signal job's hiring
 manager), and **multithread** contacts; use `FindMatchAndEnrichPeople` +
-`related_people` to map buyers ↔ implementers. Keep to 2–3.
+`related_people` to map buyers ↔ implementers. Keep to 2–3. In the deliverable these render
+as a labelled buying group — team + path to the buyer + role-tagged contacts, not a bare list.
 
 **Freshness gate (required before any name reaches the deliverable).** Sumble
 people records go stale — departed execs still listed as current, and current

--- a/skills/sumble-account-research/assets/intelligence-brief-template.html
+++ b/skills/sumble-account-research/assets/intelligence-brief-template.html
@@ -78,6 +78,18 @@ a.lnk:hover{border-color:var(--green-700)}
 .detail-col p{font-size:12.5px;color:var(--slate-600);line-height:1.55}
 .detail-col p strong{color:var(--slate-900);font-weight:600}
 .call-line{font-style:italic;color:var(--green-800);font-weight:500}
+/* Buying-group header: the real Sumble team that owns the signal + the path to the buyer.
+   Team must be a navigable team (matched_features slug), never a noisy auto-cluster; no curated
+   team -> name the function and link the org people page. See references/interactive-brief.md. */
+.buygroup{margin-top:16px;margin-bottom:10px;padding:11px 13px;background:var(--slate-50);border:1px solid var(--slate-200);border-radius:8px}
+.bg-head{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+.bg-lbl{font-family:var(--font-mono);font-size:9.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--green-700);font-weight:500}
+.bg-team{font-family:var(--font-display);font-size:13.5px;font-weight:600;color:var(--slate-900)}
+.bg-roster{margin-left:auto;font-family:var(--font-mono);font-size:10.5px;color:var(--green-700);text-decoration:none;border-bottom:1px solid rgba(21,128,61,.32);white-space:nowrap}
+.bg-path{margin-top:7px;font-size:11.5px;color:var(--slate-600)}
+.bg-path .k{font-family:var(--font-mono);font-size:9px;text-transform:uppercase;letter-spacing:.06em;color:var(--slate-400);margin-right:7px}
+.contact-role{flex-shrink:0;align-self:flex-start;font-family:var(--font-mono);font-size:9px;font-weight:500;text-transform:uppercase;letter-spacing:.05em;padding:3px 7px;border-radius:5px;background:var(--green-50);color:var(--green-800);border:1px solid var(--green-200);white-space:nowrap}
+.contact-role.multi{background:var(--slate-100);color:var(--slate-600);border-color:var(--slate-200)}
 .contacts-label{font-family:var(--font-mono);font-size:10px;text-transform:uppercase;letter-spacing:.08em;color:var(--slate-400);margin-bottom:8px}
 .contact-row{display:flex;align-items:flex-start;gap:11px;padding:10px 12px;background:var(--slate-50);border:1px solid var(--slate-100);border-radius:8px;margin-bottom:6px;transition:border-color .12s}
 .contact-row:last-child{margin-bottom:0}
@@ -198,16 +210,27 @@ a.lnk:hover{border-color:var(--green-700)}
         <div class="detail-col"><div class="detail-col-label">The call</div><p class="call-line">"{{Opening line — seller's voice, no Sumble data vocabulary}}"</p></div>
         <div class="detail-col"><div class="detail-col-label">What to test</div><p>{{Discovery question(s); <strong>bold</strong> the one key qualifier.}}</p></div>
       </div>
+      <!-- Buying-group header: the REAL Sumble team that owns this signal + the path to the buyer.
+           Team must be a navigable team (a matched_features team slug), never a noisy auto-cluster.
+           No curated team -> name the function and point the roster at the org people page. -->
+      <div class="buygroup">
+        <div class="bg-head">
+          <span class="bg-lbl">Buying group</span>
+          <span class="bg-team">{{Team name}}</span>
+          <a class="bg-roster" href="https://sumble.com/orgs/{{ORG_SLUG}}/teams/{{TEAM_SLUG}}/people">See who's on this team →</a>
+        </div>
+        <div class="bg-path"><span class="k">Path in</span>{{Champion name}} (champion) → {{Buyer name}} (economic buyer)</div>
+      </div>
       <div class="contacts-label">Contacts</div>
-      <!-- Every contact carries BOTH links: LinkedIn + the API's sumble_url
-           (https://sumble.com/l/person/...). The Sumble page is where the reporting-line
-           confidence scores live. Applies to economic buyer, champion, and multithread alike. -->
+      <!-- Every contact carries BOTH links (LinkedIn + the API's sumble_url — the Sumble page is where the
+           reporting-line confidence scores live) AND a role chip: "Economic buyer" / "Champion" (green) or
+           "Multithread" (class="contact-role multi", slate). Applies to every contact on the card. -->
       <div class="contact-row"><div class="contact-av">{{IN}}</div><div class="contact-info">
         <div class="contact-name">{{Full Name}}<span class="plinks"><a href="{{LINKEDIN_URL}}">LinkedIn</a><span class="sep">·</span><a href="{{SUMBLE_PERSON_URL}}">Sumble</a></span></div>
         <div class="contact-title">{{Title}}</div>
         <div class="contact-loc">{{Location · why this person, per the play's persona}}</div>
-      </div></div>
-      <!-- 1-2 more contact-row blocks: economic buyer, champion/user, multithread -->
+      </div><span class="contact-role">{{Economic buyer / Champion}}</span></div>
+      <!-- 1-2 more contact-row blocks; use <span class="contact-role multi">Multithread</span> for the slate chip -->
       <!-- Reporting-context fan-out: ONE .fan block per contact on this card — each contact is its own anchor.
            Rows are the contact's DIRECT REPORTS (▼) from FindMatchAndEnrichPeople match mode with
            related_people:{direction:["direct_reports"], attributes:[...,"confidence"]} — batch all a card's

--- a/skills/sumble-account-research/assets/intelligence-brief-template.html
+++ b/skills/sumble-account-research/assets/intelligence-brief-template.html
@@ -87,6 +87,13 @@ a.lnk:hover{border-color:var(--green-700)}
 .contact-name{font-size:12.5px;font-weight:600;color:var(--slate-900);margin-bottom:1px}
 .contact-title{font-size:11.5px;color:var(--slate-600);margin-bottom:1px}
 .contact-loc{font-size:11px;color:var(--slate-400)}
+.plinks{font-family:var(--font-mono);font-size:10px;font-weight:500;white-space:nowrap}
+.plinks a{color:var(--slate-500);border-bottom:1px solid var(--slate-200);text-decoration:none}
+.plinks a:hover{color:var(--green-700);border-color:var(--green-700)}
+.plinks .sep{color:var(--slate-300);margin:0 5px}
+.contact-name .plinks{margin-left:7px;font-weight:500}
+.fan-row .plinks{margin-left:auto;padding-left:8px}
+.fan-anchor .plinks{margin-left:auto}
 /* Per-contact reporting-context fan-out. One .fan per surfaced contact; each is its own anchor + above/below,
    each row carrying the Sumble 1-10 match confidence (or .na when the MCP returns no score). */
 .orgtree{margin-top:16px}
@@ -192,34 +199,39 @@ a.lnk:hover{border-color:var(--green-700)}
         <div class="detail-col"><div class="detail-col-label">What to test</div><p>{{Discovery question(s); <strong>bold</strong> the one key qualifier.}}</p></div>
       </div>
       <div class="contacts-label">Contacts</div>
+      <!-- Every contact carries BOTH links: LinkedIn + the API's sumble_url
+           (https://sumble.com/l/person/...). The Sumble page is where the reporting-line
+           confidence scores live. Applies to economic buyer, champion, and multithread alike. -->
       <div class="contact-row"><div class="contact-av">{{IN}}</div><div class="contact-info">
-        <div class="contact-name"><a class="lnk" href="{{LINKEDIN_URL}}">{{Full Name}}</a></div>
+        <div class="contact-name">{{Full Name}}<span class="plinks"><a href="{{LINKEDIN_URL}}">LinkedIn</a><span class="sep">·</span><a href="{{SUMBLE_PERSON_URL}}">Sumble</a></span></div>
         <div class="contact-title">{{Title}}</div>
         <div class="contact-loc">{{Location · why this person, per the play's persona}}</div>
       </div></div>
       <!-- 1-2 more contact-row blocks: economic buyer, champion/user, multithread -->
       <!-- Reporting-context fan-out: ONE .fan block per contact on this card — each contact is its own anchor.
-           Rows above/below come from FindMatchAndEnrichPeople with related_people (run per contact). The 1-10
-           .fan-rank is the Sumble match/relatedness confidence, normalized max(0.1, ceil(score*100)/10).
-           Inferred line, NOT a confirmed org chart. ~2 above + ~3 below, strongest first.
-           If the MCP returns no numeric score, use class "fan-rank na" with "—" and say so in the note.
-           If a contact has no related people, render a .fan-none note instead of padding. Never fabricate. -->
+           Rows are the contact's DIRECT REPORTS (▼) from FindMatchAndEnrichPeople match mode with
+           related_people:{direction:["direct_reports"], attributes:[...,"confidence"]} — batch all a card's
+           contacts in ONE call. The .fan-rank is the REAL Sumble 1-10: ceil(confidence.score*100)/10
+           (confidence.score is a 0-1 float at the top level of each report). Top ~5 by score. Every row
+           carries LinkedIn + the report's sumble_url — same as the contact rows.
+           Managers (▲/up) are near-empty for senior contacts — don't render an empty "above" fan.
+           Noisy/off-target line (common for CXOs; or a stale record with 0 reports) → .fan-none note, never pad. -->
       <div class="orgtree">
-        <div class="orgtree-label">Reporting context · Sumble confidence 1–10</div>
+        <div class="orgtree-label">Who rolls up to them · Sumble confidence 1–10</div>
         <div class="fan">
-          <div class="fan-anchor"><span class="nm"><a class="lnk" href="{{LINKEDIN_URL}}">{{Contact 1 Name}}</a></span> · <span class="tt">{{Contact 1 Title}}</span></div>
+          <div class="fan-anchor"><span class="nm">{{Contact 1 Name}}</span> · <span class="tt">{{Contact 1 Title}}</span><span class="plinks"><a href="{{LINKEDIN_URL}}">LinkedIn</a><span class="sep">·</span><a href="{{SUMBLE_PERSON_URL}}">Sumble</a></span></div>
           <div class="fan-branch">
-            <div class="fan-row"><span class="fan-dir up">▲</span><span class="fan-rank">{{5.6}}</span><span class="nm"><a class="lnk" href="{{LINKEDIN_URL}}">{{Name}}</a></span> · <span class="tt">{{Title}}</span></div>
-            <div class="fan-row"><span class="fan-dir dn">▼</span><span class="fan-rank">{{6.5}}</span><span class="nm"><a class="lnk" href="{{LINKEDIN_URL}}">{{Name}}</a></span> · <span class="tt">{{Title}}</span></div>
-            <!-- more ▼ below rows -->
+            <div class="fan-row"><span class="fan-dir dn">▼</span><span class="fan-rank">{{6.5}}</span><span class="nm">{{Name}}</span> · <span class="tt">{{Title}}</span><span class="plinks"><a href="{{LINKEDIN_URL}}">LinkedIn</a><span class="sep">·</span><a href="{{SUMBLE_PERSON_URL}}">Sumble</a></span></div>
+            <div class="fan-row"><span class="fan-dir dn">▼</span><span class="fan-rank">{{5.6}}</span><span class="nm">{{Name}}</span> · <span class="tt">{{Title}}</span><span class="plinks"><a href="{{LINKEDIN_URL}}">LinkedIn</a><span class="sep">·</span><a href="{{SUMBLE_PERSON_URL}}">Sumble</a></span></div>
+            <!-- more ▼ rows, top ~5 by score -->
           </div>
         </div>
         <div class="fan">
-          <div class="fan-anchor"><span class="nm"><a class="lnk" href="{{LINKEDIN_URL}}">{{Contact 2 Name}}</a></span> · <span class="tt">{{Contact 2 Title}}</span></div>
-          <div class="fan-none">No related people surfaced in Sumble for this profile — reach directly, or warm-intro via another contact's line.</div>
+          <div class="fan-anchor"><span class="nm">{{Contact 2 Name}}</span> · <span class="tt">{{Contact 2 Title}}</span><span class="plinks"><a href="{{LINKEDIN_URL}}">LinkedIn</a><span class="sep">·</span><a href="{{SUMBLE_PERSON_URL}}">Sumble</a></span></div>
+          <div class="fan-none">Sumble-inferred line is thin/off-target for this profile — reach directly, or warm-intro via the champion's line.</div>
         </div>
         <!-- one .fan block per remaining contact -->
-        <div class="orgtree-note">Inferred reporting lines from shared signals (tech, function, team, title) — a suggested map, not a confirmed org chart. ▲ = leadership above, ▼ = reports/peers below. Score = Sumble's confidence (1–10) that the person sits in that contact's reporting line, not confidence the play will land.</div>
+        <div class="orgtree-note">Inferred reporting lines from shared signals (tech, function, team, title, location) — the same 1–10 shown on each person's Sumble page. A suggested map, not a confirmed org chart. ▼ = who Sumble thinks reports to that contact. Score = confidence the person sits in that line, not confidence the play will land.</div>
       </div>
       <div class="sources">Evidence: <a href="{{SUMBLE_ORG_URL}}">Sumble · {{ACCOUNT}} profile</a>{{ · web sources}}</div>
     </div></div>

--- a/skills/sumble-account-research/references/interactive-brief.md
+++ b/skills/sumble-account-research/references/interactive-brief.md
@@ -62,25 +62,57 @@ Order strongest-first; each card maps one Step 5b signal to one play.
 
 ## Contacts + the reporting fan-out
 
+**Freshness gate first (SKILL.md Step 5c).** Only include people *currently at the
+company*. Verify each name (web / current LinkedIn role) before it goes on a card.
+Departed → drop (don't list, don't anchor a fan-out, don't reveal). Active but with a
+stale Sumble record (wrong title / mislabeled / 0 reports) → keep, but show the
+**verified current title** (not the Sumble one) and note the record is stale. Same for
+fan-out reports: a departed report comes off the line.
+
 Per card, surface the Step 5c people (economic buyer, champion/user, multithread — 2–3).
-Each is a `.contact-row`: avatar initials, name → LinkedIn, title, `location ·
-why-this-person` (tied to the play's persona). Then a `.fan` block per contact — people
-above (`▲`) and below (`▼`):
+Each is a `.contact-row`: avatar initials, name, then **both a LinkedIn link and a Sumble
+people-page link** (`.plinks` → `LinkedIn · Sumble`), title, and `location · why-this-person`
+(tied to the play's persona). Then a `.fan` block per contact — their **direct reports**
+(who rolls up to them, `▼`), each row carrying the **real Sumble 1–10 confidence** and its
+own LinkedIn + Sumble links.
 
-1. `FindMatchAndEnrichPeople` with **`related_people`**, once per contact (1 cr per
-   related person). Returns each person's direction + LinkedIn/Sumble URLs.
-2. **Score** (`.fan-rank`) = Sumble's match/relatedness confidence the person sits in that
-   line. Normalize the 0–1 score like the web app: `max(0.1, ceil(score*100)/10)` (`0.56
-   → 5.6`, `0.65 → 6.5`).
-3. **No numeric score → don't fabricate:** render `fan-rank na` with `—`, keep the people,
-   and note in `.orgtree-note` that the number wasn't available.
-4. ~2 above + ~3 below, strongest first. No related people → `.fan-none` note; never pad
-   with invented reports.
+**One call gets the scores + both links.** `FindMatchAndEnrichPeople` in **match mode**,
+batching all a card's contacts by `person_id`/`linkedin_url`, with the reporting line and
+its confidence requested *inside* `related_people` (the inner `attributes` is what returns
+names/titles/links/scores — omit it and you get bare ids with no score):
 
-**Load-bearing honesty:** the fan-out is an *inferred* map from shared signals, not a
-confirmed org chart, and the score is confidence-the-person-is-in-that-line, **not**
-confidence-the-play-lands. Keep the `.orgtree-note` disclaimer. "Above" is often sparse
-for senior contacts — show what's there.
+```
+attributes: ["name","job_title","job_level","linkedin_url"]
+related_people: { direction: ["direct_reports"],
+                  attributes: ["name","job_title","job_level","linkedin_url","confidence"] }
+```
+
+1. **Sumble link** = each person's free `sumble_url` (`https://sumble.com/l/person/…`),
+   returned on the contact **and** every related person. Put it next to the LinkedIn link on
+   every row — anchor contacts and fan rows alike. That Sumble page is where the user sees
+   the full confidence-scored roll-up.
+2. **Score** (`.fan-rank`) = each related person's `confidence.score` (a 0–1 float at the
+   **top level** of the report object, *not* under `attributes`). Convert to the web app's
+   1–10 exactly: `ceil(score*100)/10` (`0.3865 → 3.9`, `0.51 → 5.1`). These are the same
+   numbers on the person's Sumble page. Rank each contact's `direct_reports` by score, show
+   the **top ~5**.
+3. **Direction.** Use `direct_reports` (`▼`). The `managers` (up) direction is near-empty
+   for senior contacts (a CXO/SVP rarely has an inferred manager) — don't render an empty
+   `▲` fan; express the path-to-buyer in prose instead.
+4. **Noisy / off-target line → don't show a misleading fan.** Common for CXOs (e.g. a CISO
+   whose top "reports" are physical-security or strategy people, or a CDAO whose Sumble
+   record is stale with 0 reports). Render a `.fan-none` note ("reach them through the
+   champion") instead of padding. Never invent reports.
+5. The response is large and usually spills to a file — read it back with `jq`
+   (`.people[].related_people.direct_reports | sort_by(-.confidence.score)`), not inline.
+
+Apply this to **every** recommended contact — the economic buyer and the champion both get
+the dual links and their scored reporting line, exactly as on the Sumble people page.
+
+**Load-bearing honesty:** the fan-out is an *inferred* map from shared signals (tech,
+function, team, title, location) — the same figure shown on each person's Sumble page — a
+suggested map, **not** a confirmed org chart, and the score is confidence-the-person-sits-in-
+that-line, **not** confidence-the-play-lands. Keep the `.orgtree-note` disclaimer.
 
 ## Deliver
 

--- a/skills/sumble-account-research/references/interactive-brief.md
+++ b/skills/sumble-account-research/references/interactive-brief.md
@@ -79,6 +79,13 @@ Order strongest-first; each card maps one Step 5b signal to one play.
 
 ## Buying group + the reporting fan-out
 
+The **buying group is defined in SKILL.md Step 5c** — the contacts, the scored reporting
+lines (`related_people` + `confidence` → 1–10), both links per person, the path in, and the
+"every person accounted for" rule. This section is just its **HTML rendering** (`.buygroup`
+header, role chips, `.fan` blocks, `.plinks`); don't re-derive the data rules here — Step 5c
+is the source of truth, and the same group feeds the deck, call-prep, and outreach
+deliverables too.
+
 **Freshness gate first (SKILL.md Step 5c).** Only include people *currently at the
 company*. Verify each name (web / current LinkedIn role) before it goes on a card.
 Departed → drop (don't list, don't anchor a fan-out, don't reveal). Active but with a

--- a/skills/sumble-account-research/references/interactive-brief.md
+++ b/skills/sumble-account-research/references/interactive-brief.md
@@ -12,6 +12,23 @@ prospect-facing, so it skips `references/branding.md`. The template already carr
 brand: one emerald accent (`#16a34a`) on slate/white, the hosted Sumble mark, Inter.
 Don't recolor it to the prospect or the seller.
 
+**Brand-font upgrade (Sumble-internal runs only).** The public template ships **Inter**
+because the NEXT brand faces (NextPoster/NextBook) are proprietary and this repo is public —
+never commit the NEXT font files here. But if you're running inside Sumble and the NEXT
+woff2 files are available locally (they ship in the private `elastic-skill` under
+`assets/brand/`, or the `sumble-brand-guidelines` skill), embed them into the **output**
+`.html` for a full brand match: base64-encode each woff2, add two `@font-face` blocks, and
+point the vars at them —
+
+```css
+@font-face{font-family:'NextPoster';src:url(data:font/woff2;base64,<POSTER_B64>) format('woff2');font-weight:300 800;font-display:swap}
+@font-face{font-family:'NextBook';src:url(data:font/woff2;base64,<BOOK_B64>) format('woff2');font-weight:300 800;font-display:swap}
+:root{--font-display:'NextPoster','Inter',system-ui,sans-serif;--font-body:'NextBook','Inter',system-ui,sans-serif;}
+```
+
+The fonts live in the delivered file only, never in the repo. No fonts handy → leave the
+template on Inter; it still renders clean.
+
 ## Map the plays to pills + badges
 
 The pills and badges are the user's **sales plays** — already settled in the Step 3
@@ -60,7 +77,7 @@ Order strongest-first; each card maps one Step 5b signal to one play.
   sentences, no "**Label:** sentence" bullets.
 - **Sources** — `Sumble · {{ACCOUNT}} profile` link plus any web sources.
 
-## Contacts + the reporting fan-out
+## Buying group + the reporting fan-out
 
 **Freshness gate first (SKILL.md Step 5c).** Only include people *currently at the
 company*. Verify each name (web / current LinkedIn role) before it goes on a card.
@@ -69,12 +86,34 @@ stale Sumble record (wrong title / mislabeled / 0 reports) → keep, but show th
 **verified current title** (not the Sumble one) and note the record is stale. Same for
 fan-out reports: a departed report comes off the line.
 
-Per card, surface the Step 5c people (economic buyer, champion/user, multithread — 2–3).
-Each is a `.contact-row`: avatar initials, name, then **both a LinkedIn link and a Sumble
-people-page link** (`.plinks` → `LinkedIn · Sumble`), title, and `location · why-this-person`
-(tied to the play's persona). Then a `.fan` block per contact — their **direct reports**
-(who rolls up to them, `▼`), each row carrying the **real Sumble 1–10 confidence** and its
-own LinkedIn + Sumble links.
+Every card ends in a **labelled buying group**: the team that owns the signal, the path to
+the buyer, the role-tagged people, then each person's scored reporting line. Don't leave the
+people as a bare list.
+
+**1 · Team header (`.buygroup`).** Anchor the card on a **real, navigable Sumble team** —
+never a noisy auto-cluster ("Manager", "AVP", a generic "Security"). The clean source is the
+team that recurs across your contacts' `FindMatchAndEnrichPeople` `confidence.matched_features`
+with `match_type:"team"` — it carries the team `name` **and `slug`**. Roster link is slug-form,
+not numeric ids: `https://sumble.com/orgs/<org-slug>/teams/<team-slug>/people`, text **"See
+who's on this team →"** (Sumble's inferred, confidence-scored membership, not a confirmed
+roster). **No curated team** — some orgs surface only the generic org-level cluster (its slug
+is just the org name, e.g. `nfl`); don't anchor on that. Name the group by the function you're
+selling into and point the roster at `https://sumble.com/orgs/<org-slug>/people` with text
+**"See who Sumble links to this org →"**, noting it in `.bg-path`.
+
+**2 · Path in (`.bg-path`).** One line naming the entry point and the buyer above it:
+`{{champion}} (champion) → {{economic buyer}} (economic buyer)`. Don't render an empty "above"
+fan for a senior contact whose inferred manager is missing — just name the path here.
+
+**3 · Contacts (`.contact-row`), each with a role chip + both links.** The 2–3 Step 5c people
+— avatar initials, name with **LinkedIn + Sumble** links (`.plinks`), title, `location ·
+why-this-person` (the play's persona) — plus a **`.contact-role` chip**: `Economic buyer` /
+`Champion` (green) or `Multithread` (`class="contact-role multi"`, slate). The role is a
+visible label, not buried in the prose.
+
+**4 · Reporting fan-out (`.fan`)** — a `.fan` block per contact: their **direct reports** (who
+rolls up to them, `▼`), each row carrying the **real Sumble 1–10 confidence** and its own
+LinkedIn + Sumble links.
 
 **One call gets the scores + both links.** `FindMatchAndEnrichPeople` in **match mode**,
 batching all a card's contacts by `person_id`/`linkedin_url`, with the reporting line and

--- a/skills/sumble-account-research/references/interactive-brief.md
+++ b/skills/sumble-account-research/references/interactive-brief.md
@@ -15,10 +15,9 @@ Don't recolor it to the prospect or the seller.
 **Brand-font upgrade (Sumble-internal runs only).** The public template ships **Inter**
 because the NEXT brand faces (NextPoster/NextBook) are proprietary and this repo is public —
 never commit the NEXT font files here. But if you're running inside Sumble and the NEXT
-woff2 files are available locally (they ship in the private `elastic-skill` under
-`assets/brand/`, or the `sumble-brand-guidelines` skill), embed them into the **output**
-`.html` for a full brand match: base64-encode each woff2, add two `@font-face` blocks, and
-point the vars at them —
+woff2 files are available locally (from a Sumble brand-assets source you already have
+installed), embed them into the **output** `.html` for a full brand match: base64-encode
+each woff2, add two `@font-face` blocks, and point the vars at them —
 
 ```css
 @font-face{font-family:'NextPoster';src:url(data:font/woff2;base64,<POSTER_B64>) format('woff2');font-weight:300 800;font-display:swap}

--- a/skills/sumble-account-research/references/interactive-brief.md
+++ b/skills/sumble-account-research/references/interactive-brief.md
@@ -115,6 +115,16 @@ visible label, not buried in the prose.
 rolls up to them, `▼`), each row carrying the **real Sumble 1–10 confidence** and its own
 LinkedIn + Sumble links.
 
+**Every listed contact gets a block — no silent omissions.** For each contact on the card,
+render **either** their own `.fan` (their reporting line) **or** a `.fan-none` note that says
+why there isn't one — *no reports mapped in Sumble*, *shown as a report under {anchor} above
+({score})*, or *reporting line already shown on the {other} card*. Never list a contact and
+leave their line out: if you didn't pull it (you batched only some anchors, or they're a VP
+with no mapped reports), say so and point the rep to reach directly. **Self-check before
+delivering: per card, the count of `.contact-row` blocks must equal the count of
+`.fan` + `.fan-none` blocks.** Don't repeat an identical fan across cards — cross-reference it
+("line shown on card N") instead.
+
 **One call gets the scores + both links.** `FindMatchAndEnrichPeople` in **match mode**,
 batching all a card's contacts by `person_id`/`linkedin_url`, with the reporting line and
 its confidence requested *inside* `related_people` (the inner `attributes` is what returns

--- a/skills/sumble-account-research/references/writing-rules.md
+++ b/skills/sumble-account-research/references/writing-rules.md
@@ -23,3 +23,26 @@ sharp rep, not a generated draft.
   fragments, and starting with And/But are all fine.
 
 > Write to one person. Use real words. Show, don't tell. Cut the rest.
+
+## Before you deliver — read it aloud (required)
+
+One pass over the whole draft before you ship it. This is what separates a sharp brief
+from a generated one — don't skip it.
+
+- **Spoken lines carry no Sumble vocabulary.** Read every "call" line and every discovery
+  question aloud as if to the prospect. No "used/mentioned", no "N postings", no "Sumble
+  sees", no raw counts — the prospect has never heard of Sumble. Counts and used/mentioned
+  framing live **only** in the Signal box and stack tags (the analyst's voice, for the
+  rep's eyes). Reword every leak.
+- **One move per call line.** If a line lists three things or the em-dash keeps going, cut
+  to the single sharpest clause. "You've got two security orgs — Irving does X, Santiago
+  does Y, Monterrey does Z…" is three lines pretending to be one.
+- **One locale throughout.** Pick US or UK spelling and hold it (no "organisation" next to
+  "optimize").
+- **Run the word swaps** above, then scan for the #1 tell (negative parallelism) and
+  em-dash addiction — a couple of em dashes across the whole brief is fine, twenty is a
+  tell.
+- **Every number and quote traces to a real result** — a `RunSqlQuery`/enrich pass, not a
+  round number you invented; JD language quoted verbatim.
+
+In your final message, say the audit ran and name anything you cut or re-tiered.


### PR DESCRIPTION
## What & why

Improvements to `/sumble-account-research`, surfaced while building a live Databricks-lens expansion plan for the NFL. Two commits:

### Commit 1 — person links + real confidence scores, and a freshness gate
- The interactive brief's org fan-out was rendering with blank scores ("—") and LinkedIn-only links. Root cause: `related_people` was requested **without its inner `attributes`**, so it returned bare ids. Fixed to match another skill pattern: `related_people:{direction:["direct_reports"], attributes:[...,"confidence"]}`; `confidence.score` (0–1, top level of each report) → `ceil(score*100)/10`; **every contact and every fan row links to both LinkedIn and its Sumble people page** (`sumble_url`).
- **Freshness gate (SKILL.md 5c):** verify every named person is *currently at the company* before it reaches a deliverable. Departed → drop. Active-but-stale record (wrong title / 0 reports) → keep, but use the verified current title and flag it.

### Commit 2 — labelled buying group, brand fonts, delivery audit
- **Buying group per card:** a real, navigable **Sumble team** (a `matched_features` team slug) as the header, a **"path in"** line (champion → economic buyer), and **role-tagged contacts** (Economic buyer / Champion / Multithread chips). SKILL.md 5c asks for a labelled buying group, not a bare list; `interactive-brief.md` documents the team-anchor rule and the no-curated-team fallback (don't anchor on the generic org-level cluster).
- **Brand-font upgrade:** optional NEXT (NextPoster/NextBook) embed for Sumble-internal runs; the public template stays on Inter and the font files are **never committed to this public repo**.
- **`writing-rules.md`:** a required "read it aloud" pre-delivery audit.

## Files
- `SKILL.md` — freshness gate + buying-group framing in Step 5c
- `references/interactive-brief.md` — brand-font upgrade, buying-group structure (team header / path-in / role chips), and the confidence/dual-link fan-out pull
- `references/writing-rules.md` — pre-delivery read-it-aloud audit
- `assets/intelligence-brief-template.html` — `.plinks` dual-links + scored direct-reports fan, plus `.buygroup` / `.bg-*` / `.contact-role` markup + CSS

## Notes
- No `metadata.toml` version bump — the publish workflow keys on changed files, not version.
- The two commits were reconciled so the buying-group redesign and the confidence/link work coexist cleanly.

---
Opened by Claude Code (Claude Opus 4.8) on behalf of @jared-sumble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
