### PR TITLE
sumble-account-research: put the product in the call line

### DIFF
--- a/skills/sumble-account-research/assets/intelligence-brief-template.html
+++ b/skills/sumble-account-research/assets/intelligence-brief-template.html
@@ -78,6 +78,7 @@ a.lnk:hover{border-color:var(--green-700)}
 .detail-col p{font-size:12.5px;color:var(--slate-600);line-height:1.55}
 .detail-col p strong{color:var(--slate-900);font-weight:600}
 .call-line{font-style:italic;color:var(--green-800);font-weight:500}
+.proof{display:block;margin-top:6px;font-family:var(--font-mono);font-size:10.5px;color:var(--slate-500);font-style:normal}
 /* Buying-group header: the real Sumble team that owns the signal + the path to the buyer.
    Team must be a navigable team (matched_features slug), never a noisy auto-cluster; no curated
    team -> name the function and link the org people page. See references/interactive-brief.md. */
@@ -203,11 +204,16 @@ a.lnk:hover{border-color:var(--green-700)}
         </div>
       </div>
       <div class="detail-cols">
-        <!-- "The call" = the seller's exact words to the prospect. NEVER use Sumble vocabulary here:
-             no "confirmed-used", no "used/mentioned", no "N postings", no "Sumble", no raw counts.
-             Say what a rep would say. Counts live in the Signal box / Stack tags only.
-             Same for "What to test" — phrase it as the rep's curiosity, not a Sumble metric. -->
-        <div class="detail-col"><div class="detail-col-label">The call</div><p class="call-line">"{{Opening line — seller's voice, no Sumble data vocabulary}}"</p></div>
+        <!-- "The call" = the seller's exact words to the prospect, and it NAMES THE PRODUCT.
+             Open on their situation, land on the specific module (not the bare vendor name) -
+             the product must match this card's play badge. Optional trailing .proof span =
+             one reference customer + concrete outcome (from GetMyCompanyProfile).
+             NEVER use Sumble vocabulary here: no "confirmed-used", no "used/mentioned", no
+             "N postings", no "Sumble", no raw counts - those live in the Signal box / Stack
+             tags only. "What to test" goes back to listening: the rep's curiosity, not a
+             second pitch and not a Sumble metric. -->
+        <div class="detail-col"><div class="detail-col-label">The call</div><p class="call-line">"{{Opening line — their situation, landing on the specific product/module}}"
+          <span class="proof">{{Reference customer &middot; concrete outcome}}</span></p></div>
         <div class="detail-col"><div class="detail-col-label">What to test</div><p>{{Discovery question(s); <strong>bold</strong> the one key qualifier.}}</p></div>
       </div>
       <!-- Buying-group header: the REAL Sumble team that owns this signal + the path to the buyer.

--- a/skills/sumble-account-research/references/interactive-brief.md
+++ b/skills/sumble-account-research/references/interactive-brief.md
@@ -67,13 +67,28 @@ Order strongest-first; each card maps one Step 5b signal to one play.
   competitor / displacement tech, or postings-only (not confirmed adopted). Append counts
   (`Splunk 42/81`) only from a real `RunSqlQuery` pass — never invent them.
 - **The call** (`.call-line`) — **one quoted sentence in the seller's voice**: what the
-  rep *says to the prospect*. **Never Sumble vocabulary** — no "used/mentioned", "N
-  postings", "Sumble sees", no raw counts. Say what a rep says ("you're running Splunk at
-  real scale — what are you paying that you shouldn't be?"). Counts stay in the Signal box
-  and Stack.
+  rep *says to the prospect*, and it **names the product**. The rep is selling, not running a
+  neutral discovery script; a card that never says what they sell hands them evidence with no
+  bridge to a deal. Three rules:
+  - **Open on their situation, land on the product.** Their evidence earns the sentence; the
+    product is the answer to it, not the greeting. "You're running Splunk at real scale, and
+    paying for every gigabyte you index — that's what our tiered storage is for" works;
+    "Have you considered our tiered storage?" does not. Same sentence, different order,
+    completely different call.
+  - **Name the specific product or module, not the company.** Add a **reference customer with a
+    concrete outcome** as a trailing `.proof` span when you have one (pull them from
+    `GetMyCompanyProfile` → `company_reference_customers`); it belongs to the rep, so keep it to
+    one clause.
+  - **The product must match the card's `sig-badge` play**, or the badge is decoration and the
+    play mapping is wrong — fix one or the other.
+
+  **Never Sumble vocabulary** — no "used/mentioned", "N postings", "Sumble sees", no raw counts.
+  The prospect has never heard of Sumble. Translate the evidence into seller language ("you're
+  running Splunk at real scale"); counts stay in the Signal box and Stack.
 - **What to test** (`.detail-col p`) — the discovery question as the rep's curiosity
-  ("how's the Splunk renewal going?"), not a metric. Bold the key qualifier. Natural
-  sentences, no "**Label:** sentence" bullets.
+  ("how's the Splunk renewal going?"), not a metric, and **not a second pitch** — the call
+  already named the product, so this block goes back to listening. Bold the key qualifier.
+  Natural sentences, no "**Label:** sentence" bullets.
 - **Sources** — `Sumble · {{ACCOUNT}} profile` link plus any web sources.
 
 ## Buying group + the reporting fan-out


### PR DESCRIPTION
## What

"The call" on each signal card now **names the product**. Previously the guidance kept the seller's own product out of the spoken line entirely, so a card handed the rep evidence plus a discovery question with no bridge to what they sell.

Three rules replace the old bullet:

1. **Open on their situation, land on the product.** Order is the whole thing — *"you're running Splunk at real scale, and paying for every gigabyte you index — that's what our tiered storage is for"* works; *"Have you considered our tiered storage?"* does not.
2. **Name the specific module, not the company.** Optional trailing `.proof` span carries one reference customer with a concrete outcome, pulled from `GetMyCompanyProfile` → `company_reference_customers`.
3. **The product must match the card's `sig-badge` play**, or the badge is decoration.

"What to test" is now explicitly **not a second pitch** — the call already named the product, so discovery goes back to listening.

## Why

A brief that never says what the seller sells reads as generic, and the rep has to invent the bridge themselves.

This also aligns with a more mature customer-facing brief generator: there, the *only* thing barred from a call line is Sumble's counting vocabulary ("confirmed-used", "N postings", "Sumble sees"), never the seller's own product. Its example lines are situation-led in exactly this shape.

## What did not change

The one hard prohibition stands: **no Sumble vocabulary in the spoken voice.** Counts and used/mentioned framing stay in the Signal box and stack tags.

## Changes

- `references/interactive-brief.md` — rewritten `.call-line` guidance + "What to test" note.
- `assets/intelligence-brief-template.html` — call-line comment updated; `.proof` span added to the call markup; `.proof` CSS added (renders on its own line, non-italic inside the italic call line).

## Testing

Built a full account plan from the updated template and verified in a browser: all 5 signal cards expand, every call line names a product and stays clean of Sumble vocabulary, proof lines render on their own line, play filter pills return the right cards, and the page makes zero remote requests.

## Note for reviewers

This repo and the internal sx vault carry the same skill in two deliberate variants: this one uses Inter and the hosted Sumble mark (license-safe for a public repo), the vault copy embeds the logo. Section structure and the recent freshness-gate / buying-group work are identical in both, so this PR is a straight additive change on top of what's already here.

For continuity: the same call-line change was published to the vault directly as v11 so teammates pick it up on their next `sx install`. Once this merges, `publish-to-vault.yml` will republish from here and the two stay converged.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

