### PR TITLE
territory-planning: suppress activity-derived output when no activity is loaded

### DIFF
--- a/skills/sumble-territory-planning/SKILL.md
+++ b/skills/sumble-territory-planning/SKILL.md
@@ -70,9 +70,28 @@ does not replace it.
 
 - **Activity sources (optional but the point of the skill)** — Google Calendar,
   Gong, Fireflies, Granola, Salesforce email, Gmail. Whichever MCPs are
-  connected. Without any of them the app still shows balance and segment fit,
-  but every account reads "not worked" and the move suggestions become
-  size-only. Say so plainly rather than letting the user think coverage is zero.
+  connected.
+
+  **With no activity loaded, everything activity-derived is SUPPRESSED, not
+  shown as zero.** Zero events does not mean zero coverage; it means the
+  question is unanswerable, and a table of 0% states the opposite. One helper,
+  `territory_lib.has_activity()` (mirrored by `hasActivityData()` in the UI), is
+  the single source of truth. When it is false:
+  - the **Coverage matrix** and the **Activation** column are removed, replaced
+    by a short note saying why (Book strength is unaffected — it reads ICP score
+    and ownership only);
+  - the **not-worked** and **strong-but-idle** flags are removed — with no
+    events every owned account trivially satisfies "not worked", so the cards
+    would indict the entire book;
+  - **move suggestions are switched off entirely.** This is the important one.
+    The rule that protects an account a rep is actively working is enforced by
+    reading `worked`; with no events that rail is silently inert and every
+    account looks fair game, so the mover would happily reassign live deals.
+    `suggest_moves` no-ops and reports `skipped_no_activity`.
+
+  The plan still does real work without activity — book balance, segment misfit,
+  double-allocation, and the unallocated pile are all ownership-structure
+  questions. Say plainly which half you are delivering.
 
 - **Sumble MCP** — only for `lookup.py`-adjacent name resolution and, on Path B,
   nothing at all. If it isn't available, install: https://docs.sumble.com/api/mcp.

--- a/skills/sumble-territory-planning/template/_build/suggest_moves.py
+++ b/skills/sumble-territory-planning/template/_build/suggest_moves.py
@@ -65,6 +65,21 @@ def main() -> None:
 
     counts = report["counts"]
     segments = plan["segments"]
+
+    # No activity loaded => the mover deliberately proposes nothing. Say so
+    # loudly: a silent "0 proposals" reads as "the books are already balanced",
+    # which is the opposite of what happened.
+    if report.get("skipped_no_activity"):
+        print(f"[moves] wrote {csv_path} · 0 proposals")
+        print(
+            "[moves] SKIPPED: no activity data is loaded, so every account reads "
+            "'not worked' and the rule that protects an account a rep is actively "
+            "working cannot fire. Proposing moves blind would risk reassigning live "
+            "deals, so nothing was proposed. Load activity sources (calendar, call "
+            "recorder, CRM email) and re-run to get move suggestions."
+        )
+        return
+
     print(f"[moves] wrote {csv_path} · {report['total']:,} proposals")
     print(
         f"[moves] misfit {counts['misfit']:,} · unallocated {counts['assign_unallocated']:,} · "

--- a/skills/sumble-territory-planning/template/_build/territory_lib.py
+++ b/skills/sumble-territory-planning/template/_build/territory_lib.py
@@ -665,6 +665,25 @@ def _propose(row: dict[str, Any], new_owner: str, reason: str) -> None:
     row["proposal_status"] = "suggested"
 
 
+def has_activity(rows: list[dict[str, Any]]) -> bool:
+    """True when ANY row carries a real activity event.
+
+    The single source of truth for "is activity loaded", shared by the CLI, the
+    app's move engine, and the UI — so all three agree on whether coverage means
+    anything. Zero events is NOT the same as zero coverage: it means the
+    question is unanswerable, and everything that reads `worked` has to be
+    suppressed rather than displayed as 0%.
+    """
+    return any(
+        to_float(r.get("meetings"))
+        + to_float(r.get("calls"))
+        + to_float(r.get("emails_out"))
+        + to_float(r.get("emails_in"))
+        > 0
+        for r in rows
+    )
+
+
 def suggest_moves(
     plan: dict[str, Any], rows: list[dict[str, Any]], reset: bool = False
 ) -> dict[str, Any]:
@@ -677,6 +696,13 @@ def suggest_moves(
     rebalance — because moving an account someone already has a relationship
     with costs more than assigning one nobody owns. The hard constraint
     everywhere: an account with activity is NEVER proposed for a move.
+
+    NO ACTIVITY LOADED => NO MOVES. That constraint is the only thing stopping
+    the mover from reassigning an account a rep is mid-deal on, and it is
+    enforced by reading `worked`. With no activity events every row reads
+    not-worked, so the rail is silently inert and every account looks fair game.
+    Proposing moves in that state is worse than proposing none, so the whole
+    engine no-ops and reports why.
 
     Decisions the user already made (accepted / rejected / manual) survive
     unless `reset`, so re-running after a review session refines the plan
@@ -702,6 +728,32 @@ def suggest_moves(
             row["proposed_owner"] = ""
             row["proposal_reason"] = ""
             row["proposal_status"] = ""
+
+    # See the docstring: without activity the "never move a worked account" rail
+    # cannot fire, so no automated proposal is trustworthy. Clear the pipeline's
+    # own suggestions (done just above) and stop. The user's accepted / manual /
+    # rejected decisions are untouched.
+    if not has_activity(rows):
+        zero_counts = {
+            "misfit": 0,
+            "assign_unallocated": 0,
+            "assign_whitespace": 0,
+            "rebalance": 0,
+        }
+        return {
+            "skipped_no_activity": True,
+            "counts": zero_counts,
+            "total": 0,
+            "cv_before": {s["key"]: 0.0 for s in segments},
+            "after_stats": book_stats(rows, all_reps, balance_cats),
+            "skipped_worked_misfits": 0,
+            "skipped_coach_misfits": 0,
+            "coach_names": sorted(coach_names),
+            "unrouted": {},
+            "frozen": sum(
+                1 for r in rows if str(r.get("proposal_status") or "") in FROZEN_STATUSES
+            ),
+        }
 
     reps_by_segment: dict[str, list[dict[str, Any]]] = {}
     for r in reps:

--- a/skills/sumble-territory-planning/template/static/app.js
+++ b/skills/sumble-territory-planning/template/static/app.js
@@ -39,17 +39,21 @@ const state = {
 };
 
 const PAGE_DESCRIPTIONS = {
-  overview: "How much of the segment's best business each rep holds (Capture), and how much of it they're working (Activation) — plus what needs attention. Click a rep to open their accounts.",
+  overview: "How much of the segment's best business each rep holds (Capture) — plus what needs attention. Click a rep to open their accounts. With activity loaded, a second table adds how much of it they're actually working (Activation).",
   accounts: "Every account. Assign any account to anyone with the dropdown in the last column — the Overview books update as you go. Filter by a flag, a rep, a segment, or the balancer's suggested moves (accept/reject inline). Click a row for its activity detail.",
   export: "Download the approved changes for your CRM, or the full sheet with every flag and activity count.",
 };
 
 // Flags read the EFFECTIVE owner (current + your allocations), so they update
 // the moment you assign an account on the Accounts tab.
+// `needsActivity: true` hides the flag entirely when no activity is loaded.
+// With zero events every owned account trivially satisfies "not worked", so
+// these cards would report the whole book as neglected when the truth is that
+// the question is unanswerable. See hasActivityData().
 const FLAGS = [
-  { key: "not_worked",       label: "Not being worked",  test: (r) => effectiveOwner(r) && !num(r.worked), cls: "flag-warn",
+  { key: "not_worked",       label: "Not being worked",  test: (r) => effectiveOwner(r) && !num(r.worked), cls: "flag-warn", needsActivity: true,
     help: "Owned, but the owner has had no meeting, call, or outbound email with them in the window." },
-  { key: "strong_idle",      label: "Strong but idle",   test: (r) => isStrong(r) && effectiveOwner(r) && !num(r.worked), cls: "flag-bad",
+  { key: "strong_idle",      label: "Strong but idle",   test: (r) => isStrong(r) && effectiveOwner(r) && !num(r.worked), cls: "flag-bad", needsActivity: true,
     help: "Among the strongest accounts by ICP score (see the cutoff on the left), owned, and nobody is working it. The most expensive kind of neglect." },
   { key: "strong_unallocated", label: "Strong but unallocated", test: (r) => isStrong(r) && !effectiveOwner(r) && !isWhitespace(r), cls: "flag-bad",
     help: "Among the strongest accounts by ICP score (see the cutoff on the left), and no active rep owns it. Allocating it clears this flag." },
@@ -72,6 +76,24 @@ const REASON_LABELS = {
 function num(v) { const n = Number(v); return Number.isFinite(n) ? n : 0; }
 function isWhitespace(r) {
   return r.account_category === "whitespace" || r.account_category === "whitespace_subsidiary";
+}
+
+/** True when ANY row carries a real activity event.
+ *
+ *  Mirrors territory_lib.has_activity() so the UI and the move engine agree.
+ *  When false, every activity-derived surface is REMOVED rather than shown as
+ *  zero: the Coverage matrix, the Activation column, the not-worked and
+ *  strong-idle flags, and the whole suggested-moves queue. Zero events means
+ *  "we cannot tell", and a 0% coverage table states the opposite.
+ *  Memoised — it is read on every render and scans every row. */
+let _hasActivity = null;
+function hasActivityData() {
+  if (_hasActivity === null) {
+    _hasActivity = state.rows.some(
+      (r) => num(r.meetings) + num(r.calls) + num(r.emails_out) + num(r.emails_in) > 0
+    );
+  }
+  return _hasActivity;
 }
 
 /** Rank all real (non-whitespace) accounts by ICP score, 1 = best, and mark the
@@ -298,8 +320,14 @@ async function applyCalibration() {
 
 // ---------------------------------------------------------------- rendering
 
+/** The flags worth showing: activity-derived ones drop out when no activity is
+ *  loaded, so they can't report an unanswerable question as a finding. */
+function activeFlags() {
+  return hasActivityData() ? FLAGS : FLAGS.filter((f) => !f.needsActivity);
+}
+
 function flagPills(r) {
-  return FLAGS.filter((f) => f.test(r))
+  return activeFlags().filter((f) => f.test(r))
     .map((f) => `<span class="flag-pill ${f.cls}">${esc(f.label)}</span>`).join(" ");
 }
 
@@ -310,6 +338,16 @@ function flagPills(r) {
  *  the on/off toggle lives there, as the primary filter, so this button has no
  *  state of its own to reflect. */
 function movesCtaHtml() {
+  // No activity => the mover deliberately proposes nothing (see
+  // territory_lib.suggest_moves). Explain that rather than showing the usual
+  // "books are balanced" empty state, which would be a flat lie.
+  if (!hasActivityData()) {
+    return `<div class="moves-cta empty">Move suggestions are off because no activity
+      data is loaded. The balancer never moves an account a rep is actively working —
+      with no meetings, calls or emails to check, that protection can't apply, so
+      proposing moves could hand away a live deal. Load activity sources and re-run
+      to turn suggestions on.</div>`;
+  }
   const n = state.rows.filter((r) => r.proposal_status === "suggested").length;
   if (!n) {
     return `<div class="moves-cta empty">No suggested moves right now — the books are
@@ -464,17 +502,29 @@ function renderOverview() {
         depthHelp: "The average segment rank of this rep's 25 strongest accounts — " +
           "1 would mean they own the segment's very best 25. Lower is better. Blank " +
           "means they hold fewer than 25 accounts in this segment." }));
-    parts.push(
-      `<h3 class="terr-h3">Coverage <span class="terr-sub">` +
-      `share worked in the last ${windowDays} days</span></h3>`);
-    parts.push(renderMatrix(
-      groups, (slice) => workedPctOf(slice), "high", (v) => `${fmt(v, 0)}%`, activationCol,
-      { matrixId: "coverage", sort: state.overviewSort.coverage, allLabel: "Whole book",
-        depthHelp: `Of this rep's 25 strongest accounts, the share touched in the last ` +
-          `${windowDays} days. Blank means they hold fewer than 25 accounts here.`,
-        allHelp: `Of every account this rep owns in this segment, the share touched in ` +
-          `the last ${windowDays} days. Compare it with Top 25: much lower is fine ` +
-          `(nobody works a whole book); much higher means they're spending time down-market.` }));
+
+    // Coverage is ENTIRELY activity-derived. With no events loaded it would
+    // render every rep at 0% — indistinguishable from a team working nothing —
+    // so drop the table and say why instead.
+    if (hasActivityData()) {
+      parts.push(
+        `<h3 class="terr-h3">Coverage <span class="terr-sub">` +
+        `share worked in the last ${windowDays} days</span></h3>`);
+      parts.push(renderMatrix(
+        groups, (slice) => workedPctOf(slice), "high", (v) => `${fmt(v, 0)}%`, activationCol,
+        { matrixId: "coverage", sort: state.overviewSort.coverage, allLabel: "Whole book",
+          depthHelp: `Of this rep's 25 strongest accounts, the share touched in the last ` +
+            `${windowDays} days. Blank means they hold fewer than 25 accounts here.`,
+          allHelp: `Of every account this rep owns in this segment, the share touched in ` +
+            `the last ${windowDays} days. Compare it with Top 25: much lower is fine ` +
+            `(nobody works a whole book); much higher means they're spending time down-market.` }));
+    } else {
+      parts.push(
+        `<div class="terr-note">No activity data loaded, so coverage cannot be ` +
+        `measured — the Coverage table, the Activation column and the ` +
+        `worked-based flags are hidden rather than shown as zero. Book strength ` +
+        `below is unaffected: it comes from ICP score and ownership only.</div>`);
+    }
   }
   $("#overview-segments").innerHTML = parts.join("");
   $$("#overview-segments .seg-pill").forEach((btn) => {
@@ -500,7 +550,7 @@ function renderOverview() {
   $("#overview-moves-cta").innerHTML = movesCtaHtml();
   wireMovesCta($("#overview-moves-cta"));
 
-  $("#highlight-cards").innerHTML = FLAGS.map((f) => {
+  $("#highlight-cards").innerHTML = activeFlags().map((f) => {
     const n = state.rows.filter(f.test).length;
     return `<button class="highlight-card ${n ? "" : "empty"}" data-flag="${f.key}" title="${esc(f.help)}">
       <span class="hc-count">${fmt(n)}</span>
@@ -793,7 +843,7 @@ function renderAccounts() {
     `</div>` +
     `<div class="filter-row filter-row-secondary">` +
     `<span class="filter-label">Also</span>` +
-    FLAGS.map((f) => {
+    activeFlags().map((f) => {
       const n = state.rows.filter(f.test).length;
       return `<button class="cat-chip ${state.filters.has(f.key) ? "active" : ""}"
         data-flag="${f.key}" title="${esc(f.help)}">${esc(f.label)}

--- a/skills/sumble-territory-planning/template/static/style.css
+++ b/skills/sumble-territory-planning/template/static/style.css
@@ -28,6 +28,11 @@
 html, body {
   margin: 0;
   padding: 0;
+  /* Nothing may widen the PAGE. Wide content (the rep matrices, the accounts
+     sheet) scrolls inside its own .table-wrap; without this a single wide table
+     drags the whole layout sideways and cuts off the topbar buttons. */
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 body {
@@ -47,9 +52,13 @@ button {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
   padding: 14px 22px;
   background: var(--bg-card);
   border-bottom: 1px solid var(--border);
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .brand {
@@ -78,6 +87,11 @@ button {
   display: flex;
   gap: 8px;
   align-items: center;
+  /* Let the meta text shrink/wrap rather than push the export buttons off the
+     right edge on a narrow window. */
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  min-width: 0;
 }
 
 #customer-name {
@@ -890,6 +904,11 @@ button {
 .table-wrap {
   max-height: calc(100vh - 200px);
   overflow-y: auto;
+  /* Wide tables must scroll inside their own box. Without this the table pushes
+     the page itself wider than the viewport and the whole layout scrolls
+     sideways — which is what made Book strength run off screen. */
+  overflow-x: auto;
+  max-width: 100%;
   border: 1px solid var(--border);
   border-radius: 6px;
 }
@@ -898,6 +917,42 @@ table {
   width: 100%;
   border-collapse: collapse;
   font-size: 13px;
+}
+
+/* Rep matrices ALWAYS fit their container. `table-layout: fixed` is the load-
+   bearing part: with auto layout the browser sizes columns to content, so a long
+   rep name or a wide header pushes the table past the viewport no matter what
+   width you ask for. Fixed layout distributes the available width instead, and
+   the cells ellipsise rather than expand. */
+.matrix-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.matrix-table th,
+.matrix-table td {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Give the rep name the slack and keep the numeric columns compact — with fixed
+   layout the browser would otherwise split every column equally. */
+.matrix-table th:first-child,
+.matrix-table td:first-child {
+  width: 30%;
+}
+
+/* Explanatory note standing in for a suppressed table (e.g. Coverage hidden
+   because no activity is loaded). */
+.terr-note {
+  margin: 4px 0 18px 0;
+  padding: 12px 14px;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--fg-dim);
 }
 
 th, td {


### PR DESCRIPTION
Zero activity events is not zero coverage — it means the question is unanswerable, and rendering it as 0% states the opposite. This makes activity-absence a first-class state instead of a silently-degraded one.

**One source of truth.** `territory_lib.has_activity()`, mirrored by `hasActivityData()` in the UI, so the CLI, the move engine, and the app always agree.

**When it's false, activity-derived output is removed, not zeroed:**
- The Coverage matrix and the Activation column are replaced by a note saying why. Book strength is unaffected — it reads ICP score and ownership only.
- The `not-worked` and `strong-but-idle` flags drop out. With no events every owned account trivially satisfies "not worked", so the cards would indict the whole book.

**The load-bearing part is the mover.** The rule that protects an account a rep is actively working is enforced by reading `worked`. With no events that rail is silently inert and every account looks fair game, so the mover would happily reassign live deals. `suggest_moves` now no-ops and returns `skipped_no_activity`; the CLI and the moves CTA both explain that instead of showing the "books are balanced" empty state, which would be a flat lie.

The early return is a superset of the normal report's keys, so no consumer changes.

**Also:** wide tables now scroll inside `.table-wrap` (`table-layout: fixed` on the rep matrices) instead of dragging the page sideways and cutting off the topbar buttons.

---
🤖 Opened by Claude Code (Claude Opus 5) on behalf of @anthonygoldbloom.
