### PR TITLE
account-scoring: export a CRM import file from the app

### DIFF
--- a/skills/sumble-account-scoring/SKILL.md
+++ b/skills/sumble-account-scoring/SKILL.md
@@ -170,6 +170,32 @@ account_scoring/{company}/
   current sliders, and the per-account breakdown panel shows the same story:
   signal contributions → base score → each boost/penalty line → final score.
 
+**CRM import export.** The table toolbar's **Download CRM import** button
+writes the rows *currently shown* (category chips + search + size filter + sort
+applied) as a narrow, mapping-friendly file:
+`crm_account_id, account_name, domain, account_category, sumble_rank,
+sumble_score, sumble_url` — the id column is **omitted entirely** when no row
+carries a real one, so the file never ships a dead column. The id matters for
+**Salesforce only**: the Data Import Wizard can match Accounts on Account ID
+when updating (Name + Site is insert-only), and Data Loader's upsert requires an
+id column. HubSpot needs nothing but `domain` — it auto-dedupes companies on
+domain name, and Record ID is optional there (a blank one just creates a new
+company). Salesforce (Data Loader / Data Import Wizard) and
+HubSpot both have a column-mapping step on import, so the headers are plain
+names — don't try to guess `__c` API names. `crm_account_id` is the Salesforce
+Account Id / HubSpot Record ID carried through **verbatim** from
+`_raw/sample.csv`, so an **update/upsert** matches by id; whitespace rows have
+it blank and import as **new** accounts matched on `domain`. Nothing in the
+pipeline invents an id — if `_raw/sample.csv` had no real CRM extract behind it,
+whatever is in that column is what you get, which is why the export blanks the
+id when it merely repeats the domain (see `examples/account-scoring`, where all
+1,945 CRM rows carry the domain as the "id"). **When the objective includes
+writing scores back to the CRM, ask for the real record id** in the Stage-1
+interview — pull `Id` from Salesforce or `Record ID` from HubSpot alongside name
+and domain. This is why `crm_account_id`,
+`crm_account_name` and `crm_url` are in the app.py passthrough list even though
+they're not shown in the table.
+
 **Two score-sheet non-negotiables (NEVER strip these — the template enforces
 both with fallbacks):**
 1. **Deep links, always.** Every Sumble count/growth signal carries a

--- a/skills/sumble-account-scoring/template/app.py
+++ b/skills/sumble-account-scoring/template/app.py
@@ -358,6 +358,12 @@ def load_state() -> dict[str, Any]:
         "ws_fit",
         "ws_fit_reason",
         "ws_filter_provider",
+        # CRM identity — not shown in the table, but needed by the in-app
+        # "Download CRM import" export so the file can be upserted straight
+        # into Salesforce / HubSpot.
+        "crm_account_id",
+        "crm_account_name",
+        "crm_url",
         *table_cols,
         *[m["column"] for m in multipliers],
     ]:

--- a/skills/sumble-account-scoring/template/static/app.js
+++ b/skills/sumble-account-scoring/template/static/app.js
@@ -1710,6 +1710,66 @@ function downloadFilteredCsv() {
   URL.revokeObjectURL(a.href);
 }
 
+// Download the rows currently shown, shaped for a CRM import: one identity
+// block the CRM can match on, then the Sumble columns to write. Both Salesforce
+// (Data Loader / Data Import Wizard) and HubSpot ask you to map columns on
+// import, so plain header names are fine — no need to guess __c API names.
+// crm_account_id is the Salesforce Account Id / HubSpot Record ID and is blank
+// for whitespace rows, which import as NEW accounts matched on domain.
+function downloadCrmCsv() {
+  const ranked = sortedFilteredRanked();
+  if (!ranked.length) return;
+  const base = state.config.sumble_url_base || "https://sumble.com/orgs/";
+  const slugCol = state.config.slug_column;
+  // Build rows first: whether the record-id column is worth emitting depends on
+  // whether ANY row has one.
+  const recs = ranked.map(({ row, score, rank }) => {
+    const domain = row.crm_url || row.url || "";
+    // Only a real record id earns the column. Some source lists fill
+    // crm_account_id with the domain (no CRM extract behind them); that is not
+    // an id, and shipping it invites an upsert keyed on a column Salesforce
+    // won't match. Domain is in its own column either way — no data is lost.
+    const raw = String(row.crm_account_id ?? "").trim();
+    const id = raw.toLowerCase() === domain.trim().toLowerCase() ? "" : raw;
+    return {
+      id,
+      values: [
+        row.crm_account_name || row[state.config.name_column] || "",
+        domain,
+        rowCategory(row),
+        rank,
+        score.toFixed(2),
+        row.sumble_url || (slugCol && row[slugCol] ? base + row[slugCol] : ""),
+      ],
+    };
+  });
+
+  // Salesforce needs the id: the Data Import Wizard can only match Accounts on
+  // Account ID when updating (Name+Site is insert-only), and Data Loader's
+  // upsert requires an id column. HubSpot doesn't — it auto-dedupes companies
+  // on domain, and Record ID is optional there. So carry the id when we have
+  // one, and drop the column entirely rather than ship it empty.
+  const hasIds = recs.some((r) => r.id);
+  const cols = [
+    ...(hasIds ? ["crm_account_id"] : []),
+    "account_name", "domain", "account_category",
+    "sumble_rank", "sumble_score", "sumble_url",
+  ];
+  const lines = [cols.map(csvCell).join(",")];
+  for (const r of recs) {
+    lines.push([...(hasIds ? [r.id] : []), ...r.values].map(csvCell).join(","));
+  }
+
+  const customer = (state.config.customer_name || "accounts")
+    .toLowerCase().replace(/[^a-z0-9]+/g, "_");
+  const blob = new Blob([lines.join("\n") + "\n"], { type: "text/csv;charset=utf-8" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = `${customer}_crm_import_${new Date().toISOString().slice(0, 10)}.csv`;
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
 // ---------- Render: per-row breakdown ----------
 
 function findRow(id) {
@@ -2615,6 +2675,8 @@ async function init() {
   // Download exactly the rows currently shown (filters + sort applied).
   const dlFiltered = document.getElementById("download-filtered");
   if (dlFiltered) dlFiltered.addEventListener("click", downloadFilteredCsv);
+  const dlCrm = document.getElementById("download-crm");
+  if (dlCrm) dlCrm.addEventListener("click", downloadCrmCsv);
   document.getElementById("page-prev").addEventListener("click", () => {
     if (state.page > 0) {
       state.page--;

--- a/skills/sumble-account-scoring/template/static/index.html
+++ b/skills/sumble-account-scoring/template/static/index.html
@@ -78,6 +78,10 @@
                   type="button"
                   title="Download a CSV of exactly the rows currently shown (category chips, search, size filter and sort applied)">
             Download filtered view</button>
+          <button id="download-crm" class="btn-download btn-download-secondary"
+                  type="button"
+                  title="Download the rows currently shown as a CRM import file: CRM account id, name, domain, category, rank, score and Sumble link — ready to upsert into Salesforce or HubSpot">
+            Download CRM import</button>
         </div>
 
         <div class="table-wrap">


### PR DESCRIPTION
The app could already download the analytic score sheet and the filtered view, but neither was importable: both use human-readable signal labels as headers, and the CRM identity columns (crm_account_id / crm_account_name / crm_url) were deliberately kept out of the client payload, so the record id was unreachable from the browser. Getting scores into Salesforce or HubSpot meant hand-editing a 60-column sheet.

"Download CRM import" writes the rows currently shown (chips + search + size filter + sort applied) as a narrow file: crm_account_id, account_name, domain, account_category, sumble_rank, sumble_score, sumble_url. Headers are plain names on purpose — both CRMs have a column-mapping step on import, so guessing __c API names buys nothing.

The id column is the load-bearing part, and only for Salesforce: the Data Import Wizard can match Accounts on Account ID when updating (Name + Site is insert-only) and Data Loader's upsert requires an id column, so without it a Salesforce customer has to VLOOKUP ids back in by hand. HubSpot needs nothing but domain — it auto-dedupes companies on domain name, and Record ID is optional there.

So the column has to be trustworthy, and it isn't always. Nothing in the pipeline invents an id; crm_account_id is passed through verbatim from _raw/sample.csv, and a source list with no CRM extract behind it can leave the domain sitting in that column — examples/account-scoring is exactly this, with the domain as the "id" for all 1,945 CRM rows. A domain in an id column is worse than a blank one: it reads as a record id to whoever maps the import, and an update keyed on it matches nothing. So a per-row id that merely repeats the domain is emitted blank, and the column is dropped entirely when no row carries a real one. No data is lost either way — domain has its own column. Nothing stricter than that: HubSpot Record IDs are numeric and external ids are arbitrary, so id-shape validation would reject valid keys.

SKILL.md also now says to ask for the real Id / Record ID in the Stage-1 interview when the objective includes writing scores back to the CRM.