### PR TITLE
Plain-language rule for account research, and a rank-pagination retry fix

### DIFF
--- a/skills/sumble-account-research/SKILL.md
+++ b/skills/sumble-account-research/SKILL.md
@@ -3,6 +3,9 @@ name: sumble-account-research
 description: "Research and prospect accounts using Sumble's MCP and other context auto-pulled from live connectors. Opens with a single question, fired before any tool call: deep dive on a specific account, or help me prioritize across my accounts (plus the account name for a deep dive). Output defaults to an account plan rendered as an interactive HTML brief. However, other outputs are also possible: outreach sequences, a deck for a meeting, call prep when the invocation asks for them."
 ---
 
+Always respond to the user in simple, plain language, following the principles of
+ISO 24495-1:2023.
+
 If the Sumble MCP isn't available, stop and get them set up first: point them at
 https://docs.sumble.com/api/mcp for the endpoint and token, and tell them to run
 `/mcp` in Claude Code (or add the server in their client's MCP settings) and

--- a/skills/sumble-account-scoring/template/_build/fetch_data.py
+++ b/skills/sumble-account-scoring/template/_build/fetch_data.py
@@ -59,6 +59,11 @@ import sumble_v6
 BATCH = 100
 MIN_BATCH = 20  # adaptive-split floor: below this, a persistent failure is fatal
 PAGE = 200  # filter mode: endpoint max limit per page
+# Rank pagination floor. An expensive filter clause — a many-term `technology IN`
+# OR'd with `technology_category IN`, say — can serve happily at a smaller limit
+# and fail outright at PAGE. `rank_stratum` halves down to this before giving up,
+# for the same reason `_fetch_orgs` halves enrichment batches.
+MIN_PAGE = 25
 RANK_PAGE_CAP = 40  # base cap on filter pages scanned per stratum (scaled to quota)
 
 # Stratified whitespace preselection weights (policy constant; same spec → same
@@ -293,22 +298,44 @@ def rank_stratum(
     `people_count_growth_1y`) and ignored by the org-level columns."""
     select = {"attributes": ["id", "name", "url"], "entities": []}
     out: list[dict] = []
-    page_cap = max(RANK_PAGE_CAP, (want + PAGE - 1) // PAGE * 4 + 5)
-    for page in range(page_cap):
-        if len(out) >= want:
-            break
+    page_size = PAGE
+    offset = 0
+    scanned = 0
+    # Scaled off MIN_PAGE, not PAGE: a halved page size needs proportionally more
+    # pages to reach `want`, and the cap must not be what stops us short.
+    page_cap = max(RANK_PAGE_CAP, (want + MIN_PAGE - 1) // MIN_PAGE * 4 + 5)
+    while scanned < page_cap and len(out) < want:
         body = {
             "filter": {"query": query},
             "select": select,
             "order_by_column": order_col,
             "order_by_direction": "DESC",
-            "limit": PAGE,
-            "offset": page * PAGE,
+            "limit": page_size,
+            "offset": offset,
         }
         if order_job_function:
             body["order_by_job_function"] = order_job_function
         resp = post(api_key, body, fatal=False)
+        scanned += 1
         if not resp:
+            # `post` has already exhausted its own retries, so a big page for an
+            # expensive clause can fail repeatedly under load and then succeed
+            # later — it is load-dependent, not a hard limit. Either way, halve
+            # and retry the SAME offset: no rows are skipped, and one costly
+            # clause no longer forfeits the stratum. Breaking out here is what
+            # made a timeout indistinguishable from "no more matches" — the
+            # caller printed a benign `got 0` and the pool silently lost 20%.
+            if page_size > MIN_PAGE:
+                page_size = max(MIN_PAGE, page_size // 2)
+                print(
+                    f"[rank]   page failed at offset {offset}; "
+                    f"retrying that page with limit {page_size}"
+                )
+                continue
+            print(
+                f"[rank]   page failed at offset {offset} even at limit {MIN_PAGE} — "
+                f"stopping this stratum with {len(out)}/{want}"
+            )
             break
         orgs = resp.get("organizations") or []
         if not orgs:
@@ -322,8 +349,9 @@ def rank_stratum(
             out.append({"name": a.get("name") or "", "url": a.get("url") or ""})
             if len(out) >= want:
                 break
-        if len(orgs) < PAGE:
+        if len(orgs) < page_size:
             break
+        offset += page_size
     return out
 
 


### PR DESCRIPTION
Two unrelated changes, one commit each.

## Account research: plain-language rule

Adds one instruction at the top of `skills/sumble-account-research/SKILL.md`:

> Always respond to the user in simple, plain language, following the principles of ISO 24495-1:2023.

It sits above the MCP check so it governs the Step 1a opening question and the whole interview, not just the deliverable. `references/writing-rules.md` already covers the written brief; this covers everything the skill says in chat.

## Account scoring: retry rank pages at a smaller limit instead of giving up

`rank_stratum` in `skills/sumble-account-scoring/template/_build/fetch_data.py` paginated at a fixed limit of 200 and broke out of the loop whenever `post` came back empty. That is also what it does when there are genuinely no more matches, so a timeout on an expensive filter clause truncated the stratum silently and `take` printed a benign `got 0`. The tech stratum is weighted 0.20, so the pool quietly lost a fifth of its candidates.

The fix halves the page size down to a `MIN_PAGE` floor of 25 on failure and retries the **same** offset, so no rows are skipped. It gives up only after failing at the floor, and prints the shortfall. `page_cap` is scaled off `MIN_PAGE` so a halved page size cannot run out of pages before reaching `want`, and the offset advances by the current page size.

### Verification

Stubbed `post` with a fake paginated backend and ran old vs new at `want=2000` (the 0.20 tech stratum of a 10k pool). Results must equal `org1..org2000` in order, so any gap, duplicate or reorder fails.

| Scenario | Old | New |
|---|---|---|
| Healthy backend | 2000/2000, 10 calls | 2000/2000, 10 calls |
| Page fails at limit >100 | **0/2000, silent** | 2000/2000, 21 calls |
| One transient blip mid-stream | **600/2000, silent** | 2000/2000, 18 calls |
| Page fails at limit >25 | **0/2000, silent** | 2000/2000, 83 calls |
| Backend always down | 0/2000, silent | 0/2000, prints the shortfall |
| `want` exceeds the universe | 0 | 5000, terminates correctly |

Every recovered run came back with no gaps and no duplicates. Healthy runs are call-for-call identical, so there is no cost in the normal path.

### Known trade-offs

- **The page cap is 7x looser.** Where the cap is the only terminator (query matches more orgs than the cap can scan, and nearly all are already in `seen`), the new code makes 325 calls scanning 65,000 rows where the old made 45 scanning 9,000. Ranking pages are free, so this is wall-clock, not credits. Wherever there is a natural end, `len(orgs) < page_size` stops it first and the cap never binds.
- **`page_size` never recovers.** One transient blip pins the stratum at 100 for the rest of the run.
- **Not run against the live endpoint** — the verification above is a stubbed backend only.

### Follow-up

Every prior commit touching `fetch_data.py` is "Sync from monorepo". Unless this fix also lands upstream, the next sync reverts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)