### PR TITLE
Install the skills as Claude plugins, straight from this repo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "sumble",
+  "description": "Sumble's open GTM skills for Claude, Codex, and Cursor.",
+  "owner": {
+    "name": "Sumble",
+    "url": "https://sumble.com"
+  },
+  "plugins": [
+    {
+      "name": "sumble-account-research",
+      "source": "./skills/sumble-account-research",
+      "description": "Research and prospect accounts using Sumble's MCP and other context auto-pulled from live connectors. Opens with a single question, fired before any tool call: deep dive on a specific account, or help me prioritize across my accounts (plus the account name for a deep dive). Output defaults to an account plan rendered as an interactive HTML brief. However, other outputs are also possible: outreach sequences, a deck for a meeting, call prep when the invocation asks for them."
+    },
+    {
+      "name": "sumble-account-scoring",
+      "source": "./skills/sumble-account-scoring",
+      "description": "Build an account-scoring AND/OR whitespace web app powered by Sumble data and optional first-party data. One skill, three objectives: score the accounts in your CRM, find whitespace (high-ICP-fit orgs NOT in your CRM), or both in one ranked sheet. Interviews the user about their ICP, pulls data from internal systems and possibly Sumble MCP, and generates a self-contained, zero-dependency Python + HTML/JS app at account_scoring/{company}/ with real-time slider re-weighting, an account-category column + filters (customer / allocated / unallocated / whitespace), and an evaluation mechanism to tune the score. Outputs a config file describing the scoring method and a Python script that applies it across all accounts."
+    },
+    {
+      "name": "sumble-crm-cleaning",
+      "source": "./skills/sumble-crm-cleaning",
+      "description": "Build a CRM-cleaning review web app powered by Sumble data. Finds (1) potential duplicate accounts \u2014 CRM accounts that resolve to the SAME Sumble organization (Sumble's matcher is the only duplicate evidence; no domain or name-similarity matching) \u2014 and (2) missing or conflicting parent/subsidiary links, by matching every account to Sumble's organization graph via POST /v6/organizations (attributes incl. parent_id/subsidiary_ids \u2014 no SQL, no RunSqlQuery). Interviews the user about their CRM source and which checks to run, pulls the account list from internal systems or a CSV, and generates a self-contained, zero-dependency Python + HTML/JS review app at crm_cleaning/{company}/ with accept/reject/skip per finding, survivor selection for merges, and an actions.csv export of every approved CRM change."
+    },
+    {
+      "name": "sumble-direct-mail-audience",
+      "source": "./skills/sumble-direct-mail-audience",
+      "description": "Install and launch the supplied Marimo app for building direct-mail audiences near company offices. Use when a user wants to research company offices with Sumble and Parallel, select job functions and seniority, filter people by distance, or run the direct-mail audience notebook. Copies the fixed app template, helps save API keys to a local .env file, installs locked dependencies with uv, and returns a local Marimo URL."
+    },
+    {
+      "name": "sumble-mcp",
+      "source": "./skills/sumble-mcp",
+      "description": "Use Sumble MCP for account research, prospecting, people/job/technology searches, organization/contact list workflows, and Sumble MCP prompt or docs authoring. Use when Codex should follow Sumble MCP tool sequencing, query rules, and credit-management guardrails."
+    },
+    {
+      "name": "sumble-people-scoring",
+      "source": "./skills/sumble-people-scoring",
+      "description": "Build a people-scoring web app powered by Sumble data and optional first-party data. Interviews the user about their ICP (job functions + skills via GetMyCompanyProfile), then builds a SMALL calibration sample from ~5 user-named companies via the unified v6 REST endpoints (POST /v6/people) so the app is ready in minutes. Optional gold set (closed-won opportunity contacts) drives an Evaluation tab and a conservative regularized weight fit. Generates a self-contained, zero-dependency Python + HTML/JS app at people_scoring/{company}/ with real-time slider re-weighting, a score.csv superset sheet, plus a production score_leads.py that applies the calibrated weights to an entire enriched CRM."
+    },
+    {
+      "name": "sumble-territory-planning",
+      "source": "./skills/sumble-territory-planning",
+      "description": "Companion to sumble-account-scoring: plan and rebalance sales territories. Interviews the user about their segments (default Enterprise + Commercial) and whether the segment line is a hard rule or should be calibrated from their data, pulls territory ownership from the CRM, and pulls per-rep\u00d7account activity (calendar meetings, Gong/Fireflies/Granola calls, Salesforce email) from whatever MCPs are connected. Generates a self-contained, zero-dependency Python + HTML/JS app at territory_planning/{company}/ with per-segment book-strength heatmaps (Capture plus each rep's top 25 accounts by average in-segment rank, and a matching coverage table), a granular account view, highlights for accounts that are not being worked / in the wrong segment / strong-but-unallocated / double-allocated / strong-but-idle (with a live top-N strong-account cutoff), and a suggest\u2192accept/reject\u2192export flow that writes an actions.csv of approved owner changes."
+    }
+  ]
+}

--- a/.github/scripts/validate_marketplace.py
+++ b/.github/scripts/validate_marketplace.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Check .claude-plugin/marketplace.json against the skills/ folders it lists.
+
+Claude installs each skill in this repo as a plugin, sourced straight at
+`./skills/<name>`, which works because every skill folder has SKILL.md at its
+root. The manifest is hand-maintained, so it drifts the moment someone adds a
+skill and forgets the entry: the skill ships in the zip and to the sx vault,
+and is simply missing from Claude.
+
+This checks four things:
+  - every skills/<name>/SKILL.md has a manifest entry
+  - every manifest entry points at a folder that exists and has a SKILL.md
+  - the entry name matches the skill's frontmatter name (that name is the
+    plugin id users type: <name>@sumble)
+  - the entry description matches the frontmatter description
+
+Entries deliberately carry NO `version` field. With a version pinned, Claude
+treats the installed copy as current and an edited skill never reaches anyone
+who already installed it; with the field absent, the version is the source
+commit and Sync delivers every change.
+
+Run locally from the repo root:
+    python3 .github/scripts/validate_marketplace.py
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+try:
+    import yaml  # PyYAML: correct scalar semantics for quoted / plain / block forms.
+except ModuleNotFoundError:  # pragma: no cover - CI installs it; guard for bare envs.
+    sys.stderr.write(
+        "PyYAML is required: pip install pyyaml (CI does this automatically).\n"
+    )
+    raise SystemExit(2)
+
+MANIFEST = pathlib.Path(".claude-plugin/marketplace.json")
+SKILLS_DIR = pathlib.Path("skills")
+
+
+def frontmatter(skill_md: pathlib.Path) -> dict:
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        raise ValueError("missing YAML frontmatter (no leading '---')")
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        raise ValueError("unterminated YAML frontmatter (no closing '---')")
+    data = yaml.safe_load(parts[1])
+    if not isinstance(data, dict):
+        raise ValueError("frontmatter is not a mapping")
+    return data
+
+
+def main() -> int:
+    if not MANIFEST.is_file():
+        sys.stderr.write(f"{MANIFEST} not found (run from the repo root)\n")
+        return 1
+
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    entries = {e.get("name"): e for e in manifest.get("plugins", [])}
+    on_disk = sorted(d.name for d in SKILLS_DIR.iterdir() if (d / "SKILL.md").is_file())
+
+    problems: list[str] = []
+
+    for name in on_disk:
+        if name not in entries:
+            problems.append(
+                f"skills/{name} has no entry in {MANIFEST} "
+                f"— it will not appear in Claude"
+            )
+
+    for name, entry in entries.items():
+        source = entry.get("source", "")
+        expected = f"./skills/{name}"
+        if source != expected:
+            problems.append(f"{name}: source is {source!r}, expected {expected!r}")
+        if "version" in entry:
+            problems.append(
+                f"{name}: remove the 'version' field — a pinned version stops "
+                f"updates reaching anyone who already installed the plugin"
+            )
+
+        skill_md = SKILLS_DIR / name / "SKILL.md"
+        if not skill_md.is_file():
+            problems.append(f"{name}: {skill_md} does not exist")
+            continue
+
+        try:
+            fm = frontmatter(skill_md)
+        except (ValueError, yaml.YAMLError) as exc:
+            problems.append(f"{name}: cannot parse {skill_md}: {exc}")
+            continue
+
+        if fm.get("name") != name:
+            problems.append(
+                f"{name}: frontmatter name is {fm.get('name')!r}; the manifest "
+                f"entry name must match, it is the id users type"
+            )
+        if fm.get("description") != entry.get("description"):
+            problems.append(
+                f"{name}: description differs from {skill_md} frontmatter "
+                f"— copy the frontmatter description into the manifest"
+            )
+
+    if problems:
+        for msg in problems:
+            print(f"::error file={MANIFEST}::{msg}")
+            print(f"FAIL {msg}", file=sys.stderr)
+        sys.stderr.write(f"\n{MANIFEST} is out of sync with skills/.\n")
+        return 1
+
+    print(f"ok   {MANIFEST} lists all {len(on_disk)} skill(s), sources and text match")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -3,6 +3,10 @@ name: Validate skills
 # Block any change that puts a SKILL.md over the Agent Skills platform limits
 # (description <= 1024 chars, name <= 64 chars, lowercase/digits/hyphens). An
 # over-long description silently breaks the skill when it's installed.
+#
+# Also check that .claude-plugin/marketplace.json still lists every skill, so a
+# new skill can't ship to the zip and the sx vault while going missing in
+# Claude.
 
 on:
   pull_request:
@@ -18,3 +22,6 @@ jobs:
         run: |
           python3 -m pip install --quiet pyyaml
           python3 .github/scripts/validate_skill_metadata.py
+
+      - name: Validate the Claude plugin marketplace manifest
+        run: python3 .github/scripts/validate_marketplace.py

--- a/README.md
+++ b/README.md
@@ -74,6 +74,32 @@ flags are fictitious, opportunity counts removed).
 
 ## Install
 
+### Claude plugins
+
+Claude installs every skill in this repo as a plugin, straight from the repo, so
+you never download anything. In Claude Desktop, web, mobile, or Cowork, open
+**Customize > Plugins > Personal**, press **+**, choose **Add marketplace > Add
+from a repository**, and enter:
+
+```
+SumbleData/sumble-skills-public
+```
+
+Install the plugins you want, then open the marketplace's **...** menu and turn
+on **Sync**, so later changes to a skill reach you without a reinstall.
+
+Claude Code does the same from the terminal:
+
+```bash
+claude plugin marketplace add SumbleData/sumble-skills-public
+claude plugin install sumble-account-research@sumble
+```
+
+The plugin ids are the skill names: `sumble-account-research@sumble`,
+`sumble-account-scoring@sumble`, `sumble-crm-cleaning@sumble`,
+`sumble-direct-mail-audience@sumble`, `sumble-mcp@sumble`,
+`sumble-people-scoring@sumble`, `sumble-territory-planning@sumble`.
+
 ### `npx skills`
 
 Run one command for the skill you want. The `skills` CLI detects supported


### PR DESCRIPTION
Adds `.claude-plugin/marketplace.json` so Claude installs these skills as plugins from the repo, instead of people downloading a zip.

## What this gives a user

**Customize > Plugins > Personal > "+" > Add marketplace > Add from a repository**, enter `SumbleData/sumble-skills-public`, install what they want, then turn on **Sync** in the marketplace's `...` menu. One path that covers Claude Desktop, web, mobile, and Cowork. Claude Code gets the same thing from `claude plugin marketplace add`.

## No restructuring of skills/

Each plugin is sourced straight at `./skills/<name>`. That works because every skill folder already has `SKILL.md` at its root, so no per-skill `.claude-plugin/plugin.json` is needed.

Verified end to end with the Claude Code CLI against a local clone:

- `claude plugin validate --strict` passes on the manifest
- all seven plugins install and enable
- `plugin details` reports the skill loading (`Skills (1)`)
- `diff -r` between each source folder and the installed cache is empty, so `references/`, `assets/` (the PNG included) and `scripts/` all arrive intact

## Why the entries carry no version field

The version was pinned at `0.1.0` in the draft manifest, and that quietly breaks updates. Tested it: edit a skill, commit, `plugin marketplace update`, `plugin update` reports *"already at the latest version (0.1.0)"* and the version-keyed cache is never refreshed. The edit never reaches anyone who already installed the plugin, which is exactly what Sync is supposed to deliver.

With the field absent, the version is the source commit (`0.1.0` -> `56794e70ea4d` on the same test) and the change lands. So there is no `version` in any entry, and `validate_marketplace.py` fails if one comes back.

## CI guard

`.github/scripts/validate_marketplace.py`, wired into the existing **Validate skills** workflow, checks that the manifest lists every skill, that each `source` resolves, that entry names match `SKILL.md` frontmatter names (that name is the id users type), and that descriptions match. The manifest is hand-maintained, so it would drift the first time someone adds a skill: the new skill would ship in the zip and to the sx vault while going missing in Claude. Happy to drop this if it feels like more than the job needs.

## Not touched

`build-skill-zips.yml` is unchanged. ChatGPT Skills and Gemini Gems still need that zip; only the Claude path changes.

## Still to verify

The GitHub-shorthand resolution (`marketplace add SumbleData/sumble-skills-public`) can only be tested once the manifest is on `main`. Everything above was tested against a local clone of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
