### PR TITLE
Sync the skills into a private Claude marketplace for the org

### DIFF
--- a/.github/scripts/build_claude_marketplace.py
+++ b/.github/scripts/build_claude_marketplace.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Vendor skills/ from this repo into a Claude plugin marketplace repo.
+
+One plugin per skill, so org admins can set a different installation
+preference (or group override) for each one.
+
+Layout produced in the target repo:
+
+    .claude-plugin/marketplace.json
+    plugins/<skill>/.claude-plugin/plugin.json
+    plugins/<skill>/skills/<skill>/SKILL.md  (+ references/, assets/, scripts/)
+
+The patch version of a plugin is bumped only when that skill's files actually
+changed, because organization auto-sync fires on a merged PR that includes a
+plugin version bump.
+
+Usage:
+    python3 build_claude_marketplace.py --skills-dir skills --target ../marketplace
+"""
+
+import argparse
+import filecmp
+import json
+import pathlib
+import shutil
+import sys
+
+import yaml
+
+# Directories inside a skill folder that are docs/marketing, not part of the
+# installable skill. Mirrors the exclusion in build-skill-zips.yml.
+EXCLUDE_DIRS = {"articles"}
+EXCLUDE_FILES = {".DS_Store"}
+
+# Deliberately NOT "sumble", which is the name the public marketplace in this
+# repo (.claude-plugin/marketplace.json) declares. Adding a second marketplace
+# under a name already in use silently REPLACES the first one: no warning, and
+# `plugin marketplace list` then shows one entry. A teammate who has this
+# internal marketplace and later follows the public install instructions would
+# lose it.
+MARKETPLACE_NAME = "sumble-internal"
+MARKETPLACE_DESCRIPTION = "Sumble's GTM skills, vendored from sumble-skills-public for the Sumble organization."
+OWNER = {"name": "Sumble", "url": "https://sumble.com"}
+
+
+def read_frontmatter(skill_md: pathlib.Path) -> dict:
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        raise SystemExit(f"{skill_md}: missing YAML frontmatter")
+    _, fm, _ = text.split("---", 2)
+    data = yaml.safe_load(fm) or {}
+    for key in ("name", "description"):
+        if not data.get(key):
+            raise SystemExit(f"{skill_md}: frontmatter is missing '{key}'")
+    return data
+
+
+def copy_skill(src: pathlib.Path, dest: pathlib.Path) -> None:
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(
+        src,
+        dest,
+        ignore=lambda _dir, names: [
+            n for n in names if n in EXCLUDE_DIRS or n in EXCLUDE_FILES
+        ],
+    )
+
+
+def trees_differ(a: pathlib.Path, b: pathlib.Path) -> bool:
+    if not a.exists() or not b.exists():
+        return True
+    cmp = filecmp.dircmp(a, b)
+
+    def walk(node) -> bool:
+        if node.left_only or node.right_only or node.diff_files or node.funny_files:
+            return True
+        return any(walk(sub) for sub in node.subdirs.values())
+
+    return walk(cmp)
+
+
+def bump_patch(version: str) -> str:
+    parts = (version or "0.0.0").split(".")
+    while len(parts) < 3:
+        parts.append("0")
+    try:
+        parts[2] = str(int(parts[2]) + 1)
+    except ValueError:
+        parts[2] = "1"
+    return ".".join(parts[:3])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skills-dir", default="skills")
+    ap.add_argument("--target", required=True, help="checkout of the marketplace repo")
+    args = ap.parse_args()
+
+    skills_dir = pathlib.Path(args.skills_dir).resolve()
+    target = pathlib.Path(args.target).resolve()
+    plugins_root = target / "plugins"
+    plugins_root.mkdir(parents=True, exist_ok=True)
+
+    entries = []
+    skill_dirs = sorted(d for d in skills_dir.iterdir() if (d / "SKILL.md").is_file())
+    if not skill_dirs:
+        raise SystemExit(f"no skills found under {skills_dir}")
+
+    for skill_dir in skill_dirs:
+        meta = read_frontmatter(skill_dir / "SKILL.md")
+        name = meta["name"]
+        plugin_dir = plugins_root / name
+        skill_dest = plugin_dir / "skills" / name
+        manifest_path = plugin_dir / ".claude-plugin" / "plugin.json"
+
+        old_manifest = {}
+        if manifest_path.is_file():
+            old_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+        staged = plugin_dir / ".staged"
+        copy_skill(skill_dir, staged)
+        changed = trees_differ(skill_dest, staged)
+        if skill_dest.exists():
+            shutil.rmtree(skill_dest)
+        skill_dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(staged), str(skill_dest))
+
+        version = old_manifest.get("version", "0.1.0")
+        if changed and old_manifest:
+            version = bump_patch(version)
+
+        manifest = {
+            "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
+            "name": name,
+            "version": version,
+            "description": meta["description"],
+            "author": OWNER,
+            "license": "MIT",
+        }
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+        entries.append(
+            {
+                "name": name,
+                "source": f"./plugins/{name}",
+                "description": meta["description"],
+            }
+        )
+        print(f"{name}: version {version}{' (bumped)' if changed and old_manifest else ''}")
+
+    # Drop plugins whose skill was deleted upstream.
+    live = {e["name"] for e in entries}
+    for stale in plugins_root.iterdir():
+        if stale.is_dir() and stale.name not in live:
+            shutil.rmtree(stale)
+            print(f"removed stale plugin {stale.name}")
+
+    marketplace = {
+        "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+        "name": MARKETPLACE_NAME,
+        "description": MARKETPLACE_DESCRIPTION,
+        "owner": OWNER,
+        "plugins": entries,
+    }
+    mp_path = target / ".claude-plugin" / "marketplace.json"
+    mp_path.parent.mkdir(parents=True, exist_ok=True)
+    mp_path.write_text(json.dumps(marketplace, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {mp_path} with {len(entries)} plugin(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/publish-to-claude-marketplace.yml
+++ b/.github/workflows/publish-to-claude-marketplace.yml
@@ -1,0 +1,111 @@
+name: Publish to Claude plugin marketplace
+
+# Vendor every skill in this repo into the private marketplace repo
+# (github.com/SumbleData/claude-plugins), which Claude organization settings
+# syncs from. Teammates get the updated skill in Claude Desktop chat and
+# Cowork without doing anything.
+#
+# The change lands as a pull request, not a direct push, because organization
+# auto-sync only fires when a PR containing a plugin version bump is merged to
+# the default branch. Direct pushes are ignored by the sync.
+#
+# The marketplace it declares is named "sumble-internal", not "sumble". The
+# public marketplace in this repo (.claude-plugin/marketplace.json) owns
+# "sumble", and adding a second marketplace under a name already in use
+# silently replaces the first.
+#
+# Setup, already done:
+#   - PRIVATE repo github.com/SumbleData/claude-plugins exists (public repos
+#     are not allowed as organization marketplace sources), with "Allow
+#     auto-merge" and "Automatically delete head branches" on.
+#
+# Setup, still needed before this workflow does anything:
+#   1. Install the Claude GitHub App on SumbleData/claude-plugins.
+#   2. Create a fine-grained PAT (or GitHub App token) with Contents: write and
+#      Pull requests: write on that repo. Store it here as the Actions secret
+#      CLAUDE_MARKETPLACE_TOKEN. Until it exists, every run exits with a skip
+#      notice.
+#   3. In Claude: Organization settings > Plugins > Add plugins > GitHub >
+#      SumbleData/claude-plugins, then turn on "Sync automatically" and set each
+#      plugin's installation preference.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+      - '.github/scripts/build_claude_marketplace.py'
+      - '.github/workflows/publish-to-claude-marketplace.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-to-claude-marketplace
+  cancel-in-progress: false
+
+env:
+  MARKETPLACE_REPO: SumbleData/claude-plugins
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      HAS_TOKEN: ${{ secrets.CLAUDE_MARKETPLACE_TOKEN != '' }}
+    steps:
+      - name: Skip notice (no token configured)
+        if: env.HAS_TOKEN != 'true'
+        run: echo "CLAUDE_MARKETPLACE_TOKEN not set — skipping. See workflow header for setup."
+
+      - name: Checkout skills
+        if: env.HAS_TOKEN == 'true'
+        uses: actions/checkout@v4
+
+      - name: Checkout marketplace repo
+        if: env.HAS_TOKEN == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.MARKETPLACE_REPO }}
+          token: ${{ secrets.CLAUDE_MARKETPLACE_TOKEN }}
+          path: marketplace
+
+      - name: Build marketplace
+        if: env.HAS_TOKEN == 'true'
+        run: |
+          python3 -m pip install --quiet pyyaml
+          python3 .github/scripts/build_claude_marketplace.py \
+            --skills-dir skills --target marketplace
+
+      - name: Open and auto-merge the sync PR
+        if: env.HAS_TOKEN == 'true'
+        working-directory: marketplace
+        env:
+          GH_TOKEN: ${{ secrets.CLAUDE_MARKETPLACE_TOKEN }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "sumble-skills-sync[bot]"
+          git config user.email "sync@sumble.com"
+
+          if git diff --quiet && git diff --cached --quiet && [ -z "$(git status --porcelain)" ]; then
+            echo "Marketplace already matches skills/ — nothing to publish."
+            exit 0
+          fi
+
+          branch="sync/skills-${SOURCE_SHA::7}"
+          git checkout -b "$branch"
+          git add -A
+          git commit -m "Sync skills from sumble-skills-public@${SOURCE_SHA::7}"
+          git push --force origin "$branch"
+
+          gh pr create \
+            --repo "$MARKETPLACE_REPO" \
+            --head "$branch" \
+            --title "Sync skills from sumble-skills-public@${SOURCE_SHA::7}" \
+            --body "Automated vendor of \`skills/\` from sumble-skills-public. Merging this triggers the Claude organization marketplace sync." \
+            || echo "PR already exists for $branch"
+
+          # Auto-merge so the sync fires without a human in the loop. Swap for
+          # a plain `gh pr merge --squash` if you'd rather review each sync.
+          gh pr merge "$branch" --repo "$MARKETPLACE_REPO" --squash --auto --delete-branch


### PR DESCRIPTION
Vendors every skill into a private marketplace repo that Claude organization settings syncs from, so teammates get an updated skill in Claude Desktop and Cowork without doing anything.

Secondary to #18, which is the path external users take.

## What is here

- `.github/scripts/build_claude_marketplace.py` writes `plugins/<skill>/.claude-plugin/plugin.json` plus `plugins/<skill>/skills/<skill>/…` into the target repo, and a marketplace manifest listing all seven. One plugin per skill, so an admin can set a different installation preference per skill.
- `.github/workflows/publish-to-claude-marketplace.yml` runs it on every push to `main` that touches `skills/`, then opens a PR and turns on auto-merge.

## Already set up

`github.com/SumbleData/claude-plugins` exists, **private** (org marketplace sources cannot be public), seeded from `main`, with *Allow auto-merge* and *Automatically delete head branches* on.

I replayed the workflow's exact git and `gh` sequence against it as a dry run: PR [claude-plugins#1](https://github.com/SumbleData/claude-plugins/pull/1) opened, auto-merged, head branch deleted. So `gh pr merge --squash --auto --delete-branch` does work on that repo with no required checks, which was the part I most expected to break.

Then verified the result installs: `claude plugin marketplace add SumbleData/claude-plugins` clones the private repo, `claude plugin install sumble-account-research@sumble-internal` succeeds, `plugin details` reports the skill loading, and `references/` and `assets/` (PNG included) are all present. `articles/` is excluded, matching the zip build.

## Still needed before it does anything

1. Install the Claude GitHub App on `SumbleData/claude-plugins`.
2. Create a fine-grained PAT with **Contents: write** and **Pull requests: write** on that repo, stored here as the Actions secret `CLAUDE_MARKETPLACE_TOKEN`. Until it exists every run exits with a skip notice, same shape as `publish-to-vault.yml`.
3. In Claude: **Organization settings > Plugins > Add plugins > GitHub > SumbleData/claude-plugins**, turn on *Sync automatically*, set each plugin's installation preference.

## Two things I changed from the draft

**The marketplace is named `sumble-internal`, not `sumble`.** Adding a second marketplace under a name already in use silently *replaces* the first: no warning, no error, `plugin marketplace list` just shows one entry afterwards. I hit this by accident while testing, with the public marketplace clobbering the internal one. Since #18 gives the public marketplace the name `sumble`, a teammate who has the org-synced internal marketplace and then follows the public install instructions would lose it. Under the two names both coexist and the same skill installs from either.

**The workflow header now says which setup steps are already done**, rather than listing all five as to-dos.

The PR-and-auto-merge flow is untouched. It differs from `publish-to-vault.yml`'s direct push because the org sync only fires on a merged PR containing a plugin version bump, and ignores direct pushes.

## On the version bump

The bump is what triggers the sync, so I tested it rather than trusting it. Editing one skill bumps that plugin alone (`0.1.0` -> `0.1.1`) and leaves the other six at `0.1.0`; a run with no source change writes nothing, so the workflow's "already matches" early exit fires instead of opening an empty PR.

I also went looking for a false-positive bug here, on the theory that `filecmp.dircmp` compares stat signatures and a fresh CI checkout resets mtimes, which would bump all seven versions on every run. It does not: `filecmp.cmp(shallow=True)` falls through to a content comparison when the signatures differ, so the detection is content-correct. Recording it so the next person does not re-derive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
