### PR TITLE
Guide: install the Claude skill from the plugin marketplace

### DIFF
--- a/skills/sumble-account-research/articles/01-research-and-prospect-an-account-in-chat.md
+++ b/skills/sumble-account-research/articles/01-research-and-prospect-an-account-in-chat.md
@@ -35,12 +35,13 @@ Two consequences worth knowing up front:
 
 ## Install it
 
-You'll need a **Sumble API key** ([sumble.com/account](https://sumble.com/account)) and the `SKILL.md` from the [`sumble-account-research`](../SKILL.md) skill.
+You'll need a **Sumble API key** ([sumble.com/account](https://sumble.com/account)). Claude installs the skill straight from a repository; ChatGPT and Gemini need the `SKILL.md` text from the [`sumble-account-research`](../SKILL.md) skill.
 
-**Claude (claude.ai or desktop): the most complete path.**
-1. **Settings → Capabilities → Skills → Upload skill**, and select the skill folder (or a zip of it) containing `SKILL.md`. *(Skills require a Pro, Team, or Enterprise plan; on Team/Enterprise an admin may need to enable them.)*
-2. **Settings → Connectors → add the Sumble MCP** (its URL plus your API key). This is what lets the skill pull real data.
-3. In any chat, just ask: *"Use account research on Vanta"* or *"Help me pick which accounts in my territory to work."* Skills trigger on intent. It works in both chat and Cowork.
+**Claude (desktop, web, mobile, or Cowork): the most complete path.**
+1. **Customize → Plugins → Personal**, press **+**, choose **Add marketplace → Add from a repository**, and enter `SumbleData/sumble-skills-public`. Install the **sumble-account-research** plugin. Nothing to download, and one marketplace covers every Sumble skill. *(Skills require a Pro, Team, or Enterprise plan; on Team/Enterprise an admin may need to enable them.)*
+2. Open the marketplace's **...** menu and turn on **Sync**, so later improvements to the skill reach you without a reinstall.
+3. **Settings → Connectors → add the Sumble MCP** (its URL plus your API key). This is what lets the skill pull real data.
+4. In any chat, just ask: *"Use account research on Vanta"* or *"Help me pick which accounts in my territory to work."* Skills trigger on intent, on every surface above.
 
 **OpenAI ChatGPT: replicate it as a Custom GPT.**
 ChatGPT has no upload-a-skill feature, so recreate the skill as a saved assistant: **Explore GPTs → Create**, and paste the `SKILL.md` text into the GPT's **Instructions**. Then connect Sumble as a **connector / action** (supported on Plus, Pro, Business, and Enterprise) so the GPT can call the Sumble MCP. Chat with that GPT to run the motion; without the connection it still drafts the plan and emails from context you provide.


### PR DESCRIPTION
Swaps one subsection of the guide: the Claude step in **Install it** now points at the plugin marketplace instead of uploading a skill folder or zip.

Depends on #18, which adds the manifest the instructions reference. Don't merge this first or the guide describes something that isn't there yet.

## The new path

**Customize → Plugins → Personal → "+" → Add marketplace → Add from a repository →** `SumbleData/sumble-skills-public` → install the plugin → turn on **Sync** in the marketplace's `...` menu.

Nothing to download, and it covers Claude Desktop, web, mobile, and Cowork in one set of steps, so the header changed from "claude.ai or desktop" to name all four.

Sync got its own step rather than a trailing clause. It's the reason this path beats uploading a zip, and it's easy to skip past.

## What I left alone

ChatGPT and Gemini are untouched and still take the `SKILL.md` text. The one knock-on edit is the lead-in sentence, which promised you'd need `SKILL.md` for all three platforms; it now says Claude installs from a repository and the other two need the file.

Same tone, four lines instead of three.

## One thing worth a separate look

The bullet above this section still says *"It's a single Markdown file. The entire skill is one `SKILL.md`."* That stopped being true once the skill grew `references/` and `assets/`. It's outside the subsection you asked me to swap, so I left it, but it's wrong today and the plugin path makes it moot for Claude users. Happy to fix it here or in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
