### PR TITLE
Give every skill folder a plugin.json so the claude.ai marketplace sync accepts it

### DIFF
--- a/.github/scripts/build_claude_marketplace.py
+++ b/.github/scripts/build_claude_marketplace.py
@@ -27,9 +27,13 @@ import sys
 
 import yaml
 
-# Directories inside a skill folder that are docs/marketing, not part of the
-# installable skill. Mirrors the exclusion in build-skill-zips.yml.
-EXCLUDE_DIRS = {"articles"}
+# Directories inside a skill folder that must not be vendored. "articles" is
+# docs/marketing, not part of the installable skill (mirrors the exclusion in
+# build-skill-zips.yml). ".claude-plugin" is the skill folder's own plugin.json
+# for the public marketplace; here the skill lands under plugins/<name>/skills/
+# and the plugin manifest is written at plugins/<name>/.claude-plugin/ instead,
+# so a nested copy would be a second, misplaced manifest.
+EXCLUDE_DIRS = {"articles", ".claude-plugin"}
 EXCLUDE_FILES = {".DS_Store"}
 
 # Deliberately NOT "sumble", which is the name the public marketplace in this

--- a/.github/scripts/validate_marketplace.py
+++ b/.github/scripts/validate_marketplace.py
@@ -7,17 +7,25 @@ root. The manifest is hand-maintained, so it drifts the moment someone adds a
 skill and forgets the entry: the skill ships in the zip and to the sx vault,
 and is simply missing from Claude.
 
-This checks four things:
+Each skill folder also carries its own .claude-plugin/plugin.json. Claude Code
+would load a bare folder with a root SKILL.md as a single-skill plugin, but the
+claude.ai marketplace sync rejected that shape ("Marketplace sync failed"), and
+every working public marketplace either ships a plugin.json per plugin or
+declares its skills explicitly. The manifest is the shape that works.
+
+This checks:
   - every skills/<name>/SKILL.md has a manifest entry
   - every manifest entry points at a folder that exists and has a SKILL.md
   - the entry name matches the skill's frontmatter name (that name is the
     plugin id users type: <name>@sumble)
   - the entry description matches the frontmatter description
+  - skills/<name>/.claude-plugin/plugin.json exists, and its name and
+    description match the frontmatter too
 
-Entries deliberately carry NO `version` field. With a version pinned, Claude
-treats the installed copy as current and an edited skill never reaches anyone
-who already installed it; with the field absent, the version is the source
-commit and Sync delivers every change.
+Neither the entries nor the plugin.json files carry a `version` field. With a
+version pinned in either place, Claude treats the installed copy as current and
+an edited skill never reaches anyone who already installed it; with the field
+absent, the version is the source commit and Sync delivers every change.
 
 Run locally from the repo root:
     python3 .github/scripts/validate_marketplace.py
@@ -105,6 +113,26 @@ def main() -> int:
                 f"— copy the frontmatter description into the manifest"
             )
 
+        plugin_json = SKILLS_DIR / name / ".claude-plugin" / "plugin.json"
+        if not plugin_json.is_file():
+            problems.append(
+                f"{name}: {plugin_json} is missing — the claude.ai marketplace "
+                f"sync rejects a plugin folder without one"
+            )
+            continue
+        pj = json.loads(plugin_json.read_text(encoding="utf-8"))
+        if pj.get("name") != name:
+            problems.append(f"{name}: {plugin_json} name is {pj.get('name')!r}")
+        if pj.get("description") != fm.get("description"):
+            problems.append(
+                f"{name}: {plugin_json} description differs from the frontmatter"
+            )
+        if "version" in pj:
+            problems.append(
+                f"{name}: remove 'version' from {plugin_json} — it pins the "
+                f"plugin and blocks updates the same way the entry field does"
+            )
+
     if problems:
         for msg in problems:
             print(f"::error file={MANIFEST}::{msg}")
@@ -112,7 +140,7 @@ def main() -> int:
         sys.stderr.write(f"\n{MANIFEST} is out of sync with skills/.\n")
         return 1
 
-    print(f"ok   {MANIFEST} lists all {len(on_disk)} skill(s), sources and text match")
+    print(f"ok   {MANIFEST} lists all {len(on_disk)} skill(s); sources, plugin.json and text match")
     return 0
 
 

--- a/skills/sumble-account-research/.claude-plugin/plugin.json
+++ b/skills/sumble-account-research/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "sumble-account-research",
+  "description": "Research and prospect accounts using Sumble's MCP and other context auto-pulled from live connectors. Opens with a single question, fired before any tool call: deep dive on a specific account, or help me prioritize across my accounts (plus the account name for a deep dive). Output defaults to an account plan rendered as an interactive HTML brief. However, other outputs are also possible: outreach sequences, a deck for a meeting, call prep when the invocation asks for them.",
+  "author": {
+    "name": "Sumble",
+    "url": "https://sumble.com"
+  },
+  "homepage": "https://github.com/SumbleData/sumble-skills-public/tree/main/skills/sumble-account-research",
+  "repository": "https://github.com/SumbleData/sumble-skills-public",
+  "license": "MIT"
+}

--- a/skills/sumble-account-scoring/.claude-plugin/plugin.json
+++ b/skills/sumble-account-scoring/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "sumble-account-scoring",
+  "description": "Build an account-scoring AND/OR whitespace web app powered by Sumble data and optional first-party data. One skill, three objectives: score the accounts in your CRM, find whitespace (high-ICP-fit orgs NOT in your CRM), or both in one ranked sheet. Interviews the user about their ICP, pulls data from internal systems and possibly Sumble MCP, and generates a self-contained, zero-dependency Python + HTML/JS app at account_scoring/{company}/ with real-time slider re-weighting, an account-category column + filters (customer / allocated / unallocated / whitespace), and an evaluation mechanism to tune the score. Outputs a config file describing the scoring method and a Python script that applies it across all accounts.",
+  "author": {
+    "name": "Sumble",
+    "url": "https://sumble.com"
+  },
+  "homepage": "https://github.com/SumbleData/sumble-skills-public/tree/main/skills/sumble-account-scoring",
+  "repository": "https://github.com/SumbleData/sumble-skills-public",
+  "license": "MIT"
+}

--- a/skills/sumble-crm-cleaning/.claude-plugin/plugin.json
+++ b/skills/sumble-crm-cleaning/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "sumble-crm-cleaning",
+  "description": "Build a CRM-cleaning review web app powered by Sumble data. Finds (1) potential duplicate accounts \u2014 CRM accounts that resolve to the SAME Sumble organization (Sumble's matcher is the only duplicate evidence; no domain or name-similarity matching) \u2014 and (2) missing or conflicting parent/subsidiary links, by matching every account to Sumble's organization graph via POST /v6/organizations (attributes incl. parent_id/subsidiary_ids \u2014 no SQL, no RunSqlQuery). Interviews the user about their CRM source and which checks to run, pulls the account list from internal systems or a CSV, and generates a self-contained, zero-dependency Python + HTML/JS review app at crm_cleaning/{company}/ with accept/reject/skip per finding, survivor selection for merges, and an actions.csv export of every approved CRM change.",
+  "author": {
+    "name": "Sumble",
+    "url": "https://sumble.com"
+  },
+  "homepage": "https://github.com/SumbleData/sumble-skills-public/tree/main/skills/sumble-crm-cleaning",
+  "repository": "https://github.com/SumbleData/sumble-skills-public",
+  "license": "MIT"
+}

--- a/skills/sumble-direct-mail-audience/.claude-plugin/plugin.json
+++ b/skills/sumble-direct-mail-audience/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "sumble-direct-mail-audience",
+  "description": "Install and launch the supplied Marimo app for building direct-mail audiences near company offices. Use when a user wants to research company offices with Sumble and Parallel, select job functions and seniority, filter people by distance, or run the direct-mail audience notebook. Copies the fixed app template, helps save API keys to a local .env file, installs locked dependencies with uv, and returns a local Marimo URL.",
+  "author": {
+    "name": "Sumble",
+    "url": "https://sumble.com"
+  },
+  "homepage": "https://github.com/SumbleData/sumble-skills-public/tree/main/skills/sumble-direct-mail-audience",
+  "repository": "https://github.com/SumbleData/sumble-skills-public",
+  "license": "MIT"
+}

--- a/skills/sumble-mcp/.claude-plugin/plugin.json
+++ b/skills/sumble-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "sumble-mcp",
+  "description": "Use Sumble MCP for account research, prospecting, people/job/technology searches, organization/contact list workflows, and Sumble MCP prompt or docs authoring. Use when Codex should follow Sumble MCP tool sequencing, query rules, and credit-management guardrails.",
+  "author": {
+    "name": "Sumble",
+    "url": "https://sumble.com"
+  },
+  "homepage": "https://github.com/SumbleData/sumble-skills-public/tree/main/skills/sumble-mcp",
+  "repository": "https://github.com/SumbleData/sumble-skills-public",
+  "license": "MIT"
+}

--- a/skills/sumble-people-scoring/.claude-plugin/plugin.json
+++ b/skills/sumble-people-scoring/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "sumble-people-scoring",
+  "description": "Build a people-scoring web app powered by Sumble data and optional first-party data. Interviews the user about their ICP (job functions + skills via GetMyCompanyProfile), then builds a SMALL calibration sample from ~5 user-named companies via the unified v6 REST endpoints (POST /v6/people) so the app is ready in minutes. Optional gold set (closed-won opportunity contacts) drives an Evaluation tab and a conservative regularized weight fit. Generates a self-contained, zero-dependency Python + HTML/JS app at people_scoring/{company}/ with real-time slider re-weighting, a score.csv superset sheet, plus a production score_leads.py that applies the calibrated weights to an entire enriched CRM.",
+  "author": {
+    "name": "Sumble",
+    "url": "https://sumble.com"
+  },
+  "homepage": "https://github.com/SumbleData/sumble-skills-public/tree/main/skills/sumble-people-scoring",
+  "repository": "https://github.com/SumbleData/sumble-skills-public",
+  "license": "MIT"
+}

--- a/skills/sumble-territory-planning/.claude-plugin/plugin.json
+++ b/skills/sumble-territory-planning/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "sumble-territory-planning",
+  "description": "Companion to sumble-account-scoring: plan and rebalance sales territories. Interviews the user about their segments (default Enterprise + Commercial) and whether the segment line is a hard rule or should be calibrated from their data, pulls territory ownership from the CRM, and pulls per-rep\u00d7account activity (calendar meetings, Gong/Fireflies/Granola calls, Salesforce email) from whatever MCPs are connected. Generates a self-contained, zero-dependency Python + HTML/JS app at territory_planning/{company}/ with per-segment book-strength heatmaps (Capture plus each rep's top 25 accounts by average in-segment rank, and a matching coverage table), a granular account view, highlights for accounts that are not being worked / in the wrong segment / strong-but-unallocated / double-allocated / strong-but-idle (with a live top-N strong-account cutoff), and a suggest\u2192accept/reject\u2192export flow that writes an actions.csv of approved owner changes.",
+  "author": {
+    "name": "Sumble",
+    "url": "https://sumble.com"
+  },
+  "homepage": "https://github.com/SumbleData/sumble-skills-public/tree/main/skills/sumble-territory-planning",
+  "repository": "https://github.com/SumbleData/sumble-skills-public",
+  "license": "MIT"
+}


### PR DESCRIPTION
Adding `SumbleData/sumble-skills-public` as a marketplace in claude.ai (Customize > Plugins > Personal) fails: *"Marketplace sync failed. Check the repository URL and try again."* The URL is right and the manifest is publicly readable, so this is the packager rejecting the plugin shape. Because the repo is public, the same failure hits every company that follows the guide we just shipped, and it isn't something they can fix on their end.

## What the working marketplaces do differently

| | source | per-plugin `plugin.json` | `version` |
|---|---|---|---|
| `anthropics/skills` | `./` + explicit `skills:[...]` + `strict:false` | none | none |
| `anthropics/claude-code` | `./plugins/<name>` | yes | mixed |
| ours, before this PR | `./skills/<name>` | none | none |

Ours relied on the root-`SKILL.md` single-skill plugin form. It is documented and the Claude Code CLI accepts it, which is how #18 got verified, but neither proven-working marketplace uses it. This PR moves us to the `anthropics/claude-code` shape: every `skills/<name>/` now carries `.claude-plugin/plugin.json` with the name and description from its frontmatter. The folders themselves do not move, so the zip build, `npx skills` and the sx vault publish are unaffected.

## Still no `version`

Not in the entries, not in `plugin.json`. Either one pins the plugin so installed users stop receiving updates (tested in #18); without it the version is the source commit, which the reference documents as the intended mode for actively developed plugins. `anthropics/skills` ships no versions and works. The CLI validator's only remaining warning, seven times over, is that omission.

## Supporting changes

- `validate_marketplace.py` now requires the `plugin.json` per skill, checks its name and description against the frontmatter, and fails on a `version` field.
- `build_claude_marketplace.py` (#19) excludes `.claude-plugin` when vendoring a skill into the private marketplace, where the plugin manifest is written at the plugin root instead. A nested copy would be a second, misplaced manifest. Verified the vendored output has none, still produces seven plugin-root manifests, and both its manifests validate.

## Verified

CLI, against a local clone of this branch: all seven plugins install and enable, each reports `Skills (1)`, and the installed trees match the source folders exactly.

## Not verified

Whether claude.ai accepts this shape. I can't drive that UI from here, so this is the leading hypothesis made concrete, not a confirmed fix. After merge, retry the add in claude.ai. If it still fails, paste `anthropics/skills` into the same dialog: if that fails too, the problem is the account's GitHub connection, not this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
