### PR TITLE
people-scoring: fix build_config.py to match the dropped Seniority factor

### DIFF
--- a/skills/sumble-people-scoring/SKILL.md
+++ b/skills/sumble-people-scoring/SKILL.md
@@ -181,7 +181,6 @@ same schema for the full CRM in production (Stage 5).
 ```
 seniority_frac  = job_level_rank / max_job_level_rank
 jf_score        = jf_range[jf].min + (jf_range[jf].max - jf_range[jf].min) * seniority_frac
-seniority_score = seniority_frac
 skill_score     = min(skill_count, skill_cap) / skill_cap   # default cap = 5
 1p_score        = {signal}_norm   # pre-normalised at merge time
 total           = Σ (weight_pct/100) * factor_score
@@ -189,13 +188,16 @@ total           = Σ (weight_pct/100) * factor_score
 
 Weights sum to 100%. `job_level_rank` comes from the canonical job-level map
 baked into `_build/sumble_v6.py` (the endpoint returns level *names* only;
-IC 0 … CXO 18).
+IC 0 … CXO 18). There is no standalone Seniority weight/factor — seniority
+only acts through `jf_score`'s min-at-IC → max-at-CXO interpolation above. An
+earlier version had a separate Seniority slider; it was removed because it
+double-counted the same signal already baked into `jf_score`.
 
 ### Default weights + calibration
 
 **Two-step weighting: policy priors, then a regularized fit to gold.**
 `build_config.py` lays down the policy defaults (Sumble-only:
-`jf=38 / seniority=46 / skills=16`; with 1P signals those scale to 75% and
+`jf=70.4 / skills=29.6`; with 1P signals those scale to 75% and
 the 1P signals split the remaining 25%; no ICP skills → the skills weight
 drops and the rest renormalise). `fit_weights.py` then nudges ONLY the
 factor blend toward separating the gold contacts — without overfitting:

--- a/skills/sumble-people-scoring/template/_build/README.md
+++ b/skills/sumble-people-scoring/template/_build/README.md
@@ -106,7 +106,8 @@ Skills are API-sourced too: the people endpoint's `technologies` attribute
 
 ## Policy constants
 
-- Weights (Sumble-only): **jf 38 / seniority 46 / skills 16**; with N 1P
+- Weights (Sumble-only): **jf 70.4 / skills 29.6** (no standalone Seniority
+  factor — it's folded into `jf_score`'s interpolation); with N 1P
   signals the Sumble factors scale to 75 and the 25 splits evenly. No ICP
   skills → the skills weight drops and the rest renormalise.
 - JF ranges: ICP `key` (0.55, 0.95); ICP `other`/unset (0.50, 0.85);

--- a/skills/sumble-people-scoring/template/_build/build_config.py
+++ b/skills/sumble-people-scoring/template/_build/build_config.py
@@ -3,9 +3,10 @@
 Deterministic: same spec + same data.calibration-info.json -> byte-identical
 config.json. The policy constants live HERE, not in agent prompts:
 
-  * Weights, Sumble-only:     jf 38 / seniority 46 / skills 16
-    (mirrors Sumble's internal people score without the Account factor).
-  * Weights, with N 1P signals: the Sumble factors keep their 38/46/16 ratio
+  * Weights, Sumble-only:     jf 70.4 / skills 29.6 (seniority is folded into
+    jf_score's min-at-IC -> max-at-CXO interpolation, not a standalone factor
+    -- see the "drop Seniority factor" note below).
+  * Weights, with N 1P signals: the Sumble factors keep their 70.4/29.6 ratio
     scaled to 75; the remaining 25 splits evenly across the 1P signals.
   * No ICP skills: the skills weight drops and the rest renormalise.
   * JF ranges: ICP personas tier `key` -> (0.55, 0.95); tier `other`/unset ->
@@ -24,7 +25,13 @@ import json
 from pathlib import Path
 
 # --- Policy constants -----------------------------------------------------------
-SUMBLE_WEIGHTS = {"jf": 38.0, "seniority": 46.0, "skills": 16.0}
+# jf 70.4 / skills 29.6 -- the 2026-07-20 "drop Seniority factor" change
+# (score_sheet.py / score_leads.py / app.js) removed the standalone Seniority
+# weight (it double-counted seniority, already baked into jf_score) and
+# renormalized the old jf 38 / seniority 46 / skills 16 split to these two.
+# This constant has to match that renormalization -- there is no "seniority"
+# key anywhere below, or config.json ships a slider the app silently ignores.
+SUMBLE_WEIGHTS = {"jf": 70.4, "skills": 29.6}
 ONE_P_TOTAL_PCT = 25.0  # with 1P signals, Sumble factors scale to 100 - this
 KEY_JF_RANGE = (0.55, 0.95)
 OTHER_JF_RANGE = (0.50, 0.85)
@@ -33,7 +40,6 @@ SKILL_CAP = 5
 
 WEIGHT_LABELS = {
     "jf": "Job Function (%)",
-    "seniority": "Seniority (%)",
     "skills": "Skills (%)",
 }
 

--- a/skills/sumble-people-scoring/template/_build/fit_weights.py
+++ b/skills/sumble-people-scoring/template/_build/fit_weights.py
@@ -2,7 +2,7 @@
 
 Runs AFTER build_config.py. Reads config.json (default weights = policy
 priors) plus data.csv (with `is_icp_gold`), and nudges ONLY the top-level
-factor blend (jf / seniority / skills / 1P signals) toward better separation
+factor blend (jf / skills / 1P signals) toward better separation
 of the gold people — deliberately a little, not a lot. The per-JF ranges are
 FROZEN: that's where overfitting would otherwise live, exactly like the
 frozen within-category weights in the account-scoring fit.
@@ -61,6 +61,9 @@ def _f(val: object, default: float = 0.0) -> float:
 
 
 def factor_scores(row: dict, config: dict) -> dict[str, float]:
+    # `config["seniority"]` (rank_column/max_rank_column) only feeds jf_score's
+    # interpolation below -- there is no standalone seniority factor/weight
+    # (dropped 2026-07-20; it double-counted seniority already baked into jf).
     sen = config.get("seniority", {})
     rank = _f(row.get(sen.get("rank_column", "job_level_rank")))
     max_rank = _f(row.get(sen.get("max_rank_column", "max_job_level_rank")))
@@ -75,7 +78,7 @@ def factor_scores(row: dict, config: dict) -> dict[str, float]:
     cap = config.get("skill_cap", 5) or 5
     skill_score = min(_f(row.get("skill_count")), cap) / cap
 
-    out = {"jf": jf_score, "seniority": sen_frac, "skills": skill_score}
+    out = {"jf": jf_score, "skills": skill_score}
     for sig in config.get("one_p_signals", []) or []:
         key = sig.get("weight_key") or f"1p_{sig.get('key')}"
         out[key] = _f(row.get(sig.get("norm_column") or f"{sig.get('key')}_norm"))


### PR DESCRIPTION
## Summary
- `build_config.py` never got updated when 42d1af94 ("People-scoring: nest JF ranges under JF weight, drop Seniority factor") removed the standalone Seniority scoring factor elsewhere in the skill. It still hardcodes `SUMBLE_WEIGHTS = {"jf": 38, "seniority": 46, "skills": 16}`, so every generated `config.json` ships a "Seniority (%)" slider (default 46%) that `score_sheet.py`/`score_leads.py`/`app.js` all silently ignore — 46 points of intended weight doing nothing, no error or warning.
- Found while running the skill end-to-end for a real customer and spot-checking the generated `score.csv` — its own zero-total-contribution-drop logic quietly removed the "Seniority (pts)" column, which is what surfaced this.
- Confirms with the template's own bundled example: `template/config.json` already ships the *correct* `jf 70.37/skills 29.63` split with no seniority key — `build_config.py` just never matched its own example.
- Fixes `build_config.py` (drop "seniority", renormalize to `jf 70.4/skills 29.6`), cleans up the same vestigial `"seniority"` key in `fit_weights.py`'s `factor_scores()` (harmless today since it's absent from `config["weights"]`, but dead/confusing code), and updates `SKILL.md` + `template/_build/README.md` so the documented weights/formula match the actual code.

## Test plan
- [x] Ran `build_config.py` against a real customer's `spec.json` (8 job functions, 33 skills, no 1P signals) — output `config.json.weights` is now `{"jf": 70.4, "skills": 29.6}`, matching the template's own reference `config.json`.
- [x] Regenerated `score.csv` for that same customer with the corrected config — header now shows `people_score`, `Job Function (pts)`, `Skills (pts)` (no dead `Seniority (pts)` column), max achievable score moved from the old broken ~36 up to the correct 70.4% × 0.95 ≈ 66.9.
- [ ] No automated test suite in this repo for the skill scripts — flagging for a maintainer's manual review/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)